### PR TITLE
Result at subscription Methods

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/ResourceSimulation.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/ResourceSimulation.java
@@ -168,12 +168,12 @@ public class ResourceSimulation implements SimulationBehaviorExtension {
 
 		if (activeResource.isEmpty()) {
 			LOGGER.error("No such active resource found! " + id.toString());
-			return Result.empty();
+			return Result.of();
 		}
 
 
 
-		return activeResource.get().onJobInitiated(jobInitiated);
+		return Result.of(activeResource.get().onJobInitiated(jobInitiated));
 	}
 
 	@Subscribe
@@ -185,11 +185,11 @@ public class ResourceSimulation implements SimulationBehaviorExtension {
 
 		if (passiveResource.isEmpty()) {
 			LOGGER.error("No such passive resource found!");
-			return Result.empty();
+			return Result.of();
 		}
 
 		final WaitingJob waitingJob = this.createWaitingJob(entity, entity.getPassiveResource().get());
-		return passiveResource.get().release(waitingJob);
+		return Result.of(passiveResource.get().release(waitingJob));
 	}
 
 	@Subscribe
@@ -202,10 +202,10 @@ public class ResourceSimulation implements SimulationBehaviorExtension {
 
 		if (activeResource.isEmpty()) {
 			LOGGER.error("No such resource found!");
-			return Result.empty();
+			return Result.of();
 		}
 
-		return activeResource.get().onJobProgressed(jobProgressed);
+		return Result.of(activeResource.get().onJobProgressed(jobProgressed));
 	}
 
 	/**
@@ -263,7 +263,7 @@ public class ResourceSimulation implements SimulationBehaviorExtension {
 		final double latency = StackContext.evaluateStatic(latencyRV.getSpecification(), Double.class);
 
 		// Now, return AppropriateResourceFound with latency
-		return Result.empty();
+		return Result.of();
 	}
 
 	/**
@@ -272,9 +272,8 @@ public class ResourceSimulation implements SimulationBehaviorExtension {
 	 * @return an empty set.
 	 */
 	@Subscribe
-	public Result<?> onSimulationFinished(final SimulationFinished simulationFinished) {
+	public void onSimulationFinished(final SimulationFinished simulationFinished) {
 		this.resourceTable.clearResourcesFromJobs();
 		this.passiveResourceTable.clearResourcesFromJobs();
-		return Result.empty();
 	}
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/ResourceSimulation.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/ResourceSimulation.java
@@ -28,6 +28,7 @@ import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.PassiveResourceAcquired;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.PassiveResourceReleased;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.ResourceDemandRequested;
+import org.palladiosimulator.analyzer.slingshot.common.events.AbstractSimulationEvent;
 //import org.palladiosimulator.analyzer.slingshot.scalingpolicy.data.events.ModelAdjusted;
 import org.palladiosimulator.analyzer.slingshot.core.events.SimulationFinished;
 import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorExtension;
@@ -84,20 +85,20 @@ public class ResourceSimulation implements SimulationBehaviorExtension {
 	}
 
 	@Subscribe
-	public Result<?> onResourceDemandRequested(final ResourceDemandRequested resourceDemandRequested) {
+	public Result<AbstractSimulationEvent> onResourceDemandRequested(final ResourceDemandRequested resourceDemandRequested) {
 		final ResourceDemandRequest request = resourceDemandRequested.getEntity();
 
 		if (request.getResourceType() == ResourceType.ACTIVE) {
-			return this.initiateActiveResource(request);
+			return Result.of(this.initiateActiveResource(request));
 		} else {
-			return this.initiatePassiveResource(request);
+			return Result.of(this.initiatePassiveResource(request));
 		}
 	}
 
 	/**
 	 * @param request
 	 */
-	private Result<PassiveResourceAcquired> initiatePassiveResource(final ResourceDemandRequest request) {
+	private PassiveResourceAcquired initiatePassiveResource(final ResourceDemandRequest request) {
 		final PassiveResource passiveResource = request.getPassiveResource().get();
 		final AssemblyContext assemblyContext = request.getAssemblyContext();
 		final Optional<SimplePassiveResource> passiveResourceInstance = this.passiveResourceTable
@@ -108,7 +109,7 @@ public class ResourceSimulation implements SimulationBehaviorExtension {
 
 			return passiveResourceInstance.get().acquire(waitingJob);
 		} else {
-			return Result.empty();
+			return null;
 		}
 	}
 
@@ -116,7 +117,7 @@ public class ResourceSimulation implements SimulationBehaviorExtension {
 	 * @param request
 	 * @return
 	 */
-	private Result<JobInitiated> initiateActiveResource(final ResourceDemandRequest request) {
+	private JobInitiated initiateActiveResource(final ResourceDemandRequest request) {
 		final double demand = StackContext.evaluateStatic(
 				request.getParametricResourceDemand().getSpecification_ParametericResourceDemand()
 						.getSpecification(),
@@ -136,7 +137,7 @@ public class ResourceSimulation implements SimulationBehaviorExtension {
 				.withAllocationContext(context)
 				.build();
 
-		return Result.of(new JobInitiated(job, 0));
+		return new JobInitiated(job, 0);
 	}
 
 	/**

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/ResourceSimulation.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/ResourceSimulation.java
@@ -98,7 +98,7 @@ public class ResourceSimulation implements SimulationBehaviorExtension {
 	/**
 	 * @param request
 	 */
-	private PassiveResourceAcquired initiatePassiveResource(final ResourceDemandRequest request) {
+	private Optional<PassiveResourceAcquired> initiatePassiveResource(final ResourceDemandRequest request) {
 		final PassiveResource passiveResource = request.getPassiveResource().get();
 		final AssemblyContext assemblyContext = request.getAssemblyContext();
 		final Optional<SimplePassiveResource> passiveResourceInstance = this.passiveResourceTable
@@ -106,11 +106,9 @@ public class ResourceSimulation implements SimulationBehaviorExtension {
 
 		if (passiveResourceInstance.isPresent()) {
 			final WaitingJob waitingJob = this.createWaitingJob(request, passiveResource);
-
 			return passiveResourceInstance.get().acquire(waitingJob);
-		} else {
-			return null;
 		}
+		return Optional.empty();
 	}
 
 	/**

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/AbstractActiveResource.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/AbstractActiveResource.java
@@ -1,12 +1,13 @@
 package org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.resources.active;
 
+import java.util.Optional;
+
 import org.apache.log4j.Logger;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.jobs.Job;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.resources.ProcessingRate;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.AbstractJobEvent;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.JobInitiated;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.resources.AbstractResource;
-import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
 import org.palladiosimulator.pcm.resourcetype.ProcessingResourceType;
 
 /**
@@ -62,7 +63,7 @@ public abstract class AbstractActiveResource extends AbstractResource implements
 	 * @param jobInitiated The event.
 	 * @return The appropriate events.
 	 */
-	protected abstract Result<AbstractJobEvent> process(final JobInitiated jobInitiated);
+	protected abstract Optional<AbstractJobEvent> process(final JobInitiated jobInitiated);
 
 	/**
 	 * Checks whether the job belongs to the resource. This is done by checking
@@ -79,9 +80,9 @@ public abstract class AbstractActiveResource extends AbstractResource implements
 	}
 
 	@Override
-	public Result<AbstractJobEvent> onJobInitiated(final JobInitiated jobInitiated) {
+	public Optional<AbstractJobEvent> onJobInitiated(final JobInitiated jobInitiated) {
 		if (!this.jobBelongsToResource(jobInitiated.getEntity())) {
-			return Result.empty();
+			return Optional.empty();
 		}
 		final double currentDemand = jobInitiated.getEntity().getDemand();
 		jobInitiated.getEntity().updateDemand(currentDemand/processingRate.calculateRV());

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/ActiveResource.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/ActiveResource.java
@@ -1,11 +1,13 @@
 package org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.resources.active;
 
+import java.util.Optional;
+import java.util.Set;
+
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.resources.IResource;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.AbstractJobEvent;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.JobFinished;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.JobInitiated;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.JobProgressed;
-import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
 
 /**
  * The active resource provides delegation methods of events, hence it "listens"
@@ -25,7 +27,7 @@ public interface ActiveResource extends IResource {
 	 * @param jobInitiated The event.
 	 * @return the appropriate events for the active resource.
 	 */
-	Result<AbstractJobEvent> onJobInitiated(final JobInitiated jobInitiated);
+	Optional<AbstractJobEvent> onJobInitiated(final JobInitiated jobInitiated);
 
 	/**
 	 * Handles the {@link JobProgressed} event. Typically, this can result in either
@@ -34,6 +36,6 @@ public interface ActiveResource extends IResource {
 	 * @param jobProgressed The event.
 	 * @return the appropriate events for the active resource.
 	 */
-	Result<AbstractJobEvent> onJobProgressed(final JobProgressed jobProgressed);
+	Set<AbstractJobEvent> onJobProgressed(final JobProgressed jobProgressed);
 
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/FCFSResource.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/FCFSResource.java
@@ -58,11 +58,7 @@ public class FCFSResource extends AbstractActiveResource {
 			return Optional.empty();
 		}
 
-		final Optional<JobProgressed> next = this.scheduleNextEvent();
-		if (next.isPresent()) {
-			return Optional.of(next.get());
-		}
-		return Optional.empty();
+		return this.scheduleNextEvent().map(j -> j);
 	}
 
 	/**

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/ProcessorSharingResource.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/ProcessorSharingResource.java
@@ -84,11 +84,7 @@ public final class ProcessorSharingResource extends AbstractActiveResource {
 		this.runningJobs.put(newJob, newJob.getDemand());
 		this.reportCoreUsage();
 
-		final Optional<ProcessorSharingJobProgressed> next = this.scheduleNextEvent();
-		if (next.isPresent()) {
-			return Optional.of(next.get());
-		}
-		return Optional.empty();
+		return this.scheduleNextEvent().map(j -> j);
 	}
 
 	/**

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/passive/SimplePassiveResource.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/passive/SimplePassiveResource.java
@@ -10,7 +10,6 @@ import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.enti
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.resources.IPassiveResource;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.resources.AbstractResource;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.PassiveResourceAcquired;
-import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
 import org.palladiosimulator.pcm.core.composition.AssemblyContext;
 import org.palladiosimulator.pcm.repository.PassiveResource;
 
@@ -80,7 +79,7 @@ public final class SimplePassiveResource extends AbstractResource implements IPa
 	 * @return {@link PassiveResourceAcquired} events for the next jobs waiting in
 	 *         the queue to be granted.
 	 */
-	public Result<PassiveResourceAcquired> release(final WaitingJob waitingJob) {
+	public Set<PassiveResourceAcquired> release(final WaitingJob waitingJob) {
 		this.available += waitingJob.getDemand();
 
 		final Set<PassiveResourceAcquired> events = new HashSet<>();
@@ -92,7 +91,7 @@ public final class SimplePassiveResource extends AbstractResource implements IPa
 			nextJob = this.waitingJobs.peek();
 		}
 
-		return Result.from(events);
+		return events;
 	}
 
 	/**

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/passive/SimplePassiveResource.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/passive/SimplePassiveResource.java
@@ -2,6 +2,7 @@ package org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.res
 
 import java.util.ArrayDeque;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 
@@ -59,13 +60,13 @@ public final class SimplePassiveResource extends AbstractResource implements IPa
 	 * @param waitingJob The job to acquire.
 	 * @return Either {@link PassiveResourceAcquired} if granted, or empty.
 	 */
-	public PassiveResourceAcquired acquire(final WaitingJob waitingJob) {
+	public Optional<PassiveResourceAcquired> acquire(final WaitingJob waitingJob) {
 		/* TODO: Throw exception if demand is higher than capacity. */
 		if (this.acquirable(waitingJob)) {
-			return grantAccess(waitingJob);
+			return Optional.of(grantAccess(waitingJob));
 		} else {
 			this.waitingJobs.offer(waitingJob);
-			return null;
+			return Optional.empty();
 		}
 	}
 

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/passive/SimplePassiveResource.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/passive/SimplePassiveResource.java
@@ -59,13 +59,13 @@ public final class SimplePassiveResource extends AbstractResource implements IPa
 	 * @param waitingJob The job to acquire.
 	 * @return Either {@link PassiveResourceAcquired} if granted, or empty.
 	 */
-	public Result<PassiveResourceAcquired> acquire(final WaitingJob waitingJob) {
+	public PassiveResourceAcquired acquire(final WaitingJob waitingJob) {
 		/* TODO: Throw exception if demand is higher than capacity. */
 		if (this.acquirable(waitingJob)) {
-			return Result.of(this.grantAccess(waitingJob));
+			return grantAccess(waitingJob);
 		} else {
 			this.waitingJobs.offer(waitingJob);
-			return Result.empty();
+			return null;
 		}
 	}
 

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SeffSimulationBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SeffSimulationBehavior.java
@@ -42,7 +42,7 @@ public class SeffSimulationBehavior implements SimulationBehaviorExtension {
 		final SeffInterpreter interpreter = new SeffInterpreter(progressed.getEntity());
 		final Set<SEFFInterpreted> events = interpreter
 				.doSwitch(progressed.getEntity().getBehaviorContext().getNextAction());
-		return Result.from(events);
+		return Result.of(events);
 	}
 
 
@@ -52,7 +52,7 @@ public class SeffSimulationBehavior implements SimulationBehaviorExtension {
 				passiveResourceAcquired.getEntity().getSeffInterpretationContext());
 		final Set<SEFFInterpreted> events = interpreter.doSwitch(passiveResourceAcquired.getEntity()
 				.getSeffInterpretationContext().getBehaviorContext().getNextAction());
-		return Result.from(events);
+		return Result.of(events);
 	}
 
 	@Subscribe
@@ -61,7 +61,7 @@ public class SeffSimulationBehavior implements SimulationBehaviorExtension {
 		final SeffInterpreter interpreter = new SeffInterpreter(seffChildInterpretationStarted.getEntity());
 		final Set<SEFFInterpreted> events = interpreter
 				.doSwitch(seffChildInterpretationStarted.getEntity().getBehaviorContext().getNextAction());
-		return Result.from(events);
+		return Result.of(events);
 	}
 
 	@Subscribe

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SeffSimulationBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SeffSimulationBehavior.java
@@ -15,6 +15,7 @@ import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.interp
 import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.entities.UserRequest;
 import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.entities.interpretationcontext.UserInterpretationContext;
 import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.events.UserRequestFinished;
+import org.palladiosimulator.analyzer.slingshot.common.events.AbstractSimulationEvent;
 import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorExtension;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.Subscribe;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.eventcontract.EventCardinality;
@@ -64,9 +65,9 @@ public class SeffSimulationBehavior implements SimulationBehaviorExtension {
 	}
 
 	@Subscribe
-	public Result<?> onSEFFInterpretationFinished(final SEFFInterpretationFinished finished) {
+	public Result<AbstractSimulationEvent> onSEFFInterpretationFinished(final SEFFInterpretationFinished finished) {
 		final SEFFInterpretationContext entity = finished.getEntity();
-		final Result<?> result;
+		final Result<AbstractSimulationEvent> result;
 		/*
 		 * If the interpretation is finished in a SEFF that was called from another
 		 * SEFF, continue there. Otherwise, the SEFF comes from a User request.
@@ -83,20 +84,20 @@ public class SeffSimulationBehavior implements SimulationBehaviorExtension {
 			} else {
 				LOGGER.info("return to parent - from forked");
 				fb.markProcessed();
-				result = this.continueInParent(entity);
+				result = Result.of(this.continueInParent(entity));
 			}
 		} else if (!entity.getBehaviorContext().hasFinished()) {
 			LOGGER.info("repeat scenario");
-			result = this.repeat(entity);
+			result = Result.of(this.repeat(entity));
 		} else if (entity.getCaller().isPresent()) {
 			LOGGER.info("return to caller");
-			result = this.continueInCaller(entity);
+			result = Result.of(this.continueInCaller(entity));
 		} else if (entity.getBehaviorContext().isChild()) {
 			LOGGER.info("return to parent");
-			result = this.continueInParent(entity);
+			result = Result.of(this.continueInParent(entity));
 		} else {
 			LOGGER.info("finish request");
-			result = this.finishUserRequest(entity);
+			result = Result.of(this.finishUserRequest(entity));
 		}
 
 		return result;
@@ -106,21 +107,21 @@ public class SeffSimulationBehavior implements SimulationBehaviorExtension {
 	 * @param entity
 	 * @return
 	 */
-	private Result<UserRequestFinished> finishUserRequest(final SEFFInterpretationContext entity) {
+	private UserRequestFinished finishUserRequest(final SEFFInterpretationContext entity) {
 		final UserRequest userRequest = entity.getRequestProcessingContext().getUserRequest();
 		final UserInterpretationContext userInterpretationContext = entity.getRequestProcessingContext()
 				.getUserInterpretationContext();
 
 		entity.getRequestProcessingContext().getUser().getStack().removeStackFrame();
 
-		return Result.of(new UserRequestFinished(userRequest, userInterpretationContext));
+		return new UserRequestFinished(userRequest, userInterpretationContext);
 	}
 
 	/**
 	 * @param entity
 	 * @return
 	 */
-	private Result<SEFFInterpretationProgressed> continueInParent(final SEFFInterpretationContext entity) {
+	private SEFFInterpretationProgressed continueInParent(final SEFFInterpretationContext entity) {
 
 		final SeffBehaviorWrapper seffBehaviorHolder = entity.getBehaviorContext().getParent().get();
 
@@ -131,20 +132,20 @@ public class SeffSimulationBehavior implements SimulationBehaviorExtension {
 				.withRequestProcessingContext(entity.getRequestProcessingContext())
 				.build();
 
-		return Result.of(new SEFFInterpretationProgressed(seffInterpretationContext));
+		return new SEFFInterpretationProgressed(seffInterpretationContext);
 	}
 
 	/**
 	 * @param entity
 	 * @return
 	 */
-	private Result<SEFFInterpretationProgressed> continueInCaller(final SEFFInterpretationContext entity) {
+	private SEFFInterpretationProgressed continueInCaller(final SEFFInterpretationContext entity) {
 		final SEFFInterpretationContext seffInterpretationContext = entity.getCaller().get();
 
-		return Result.of(new SEFFInterpretationProgressed(seffInterpretationContext));
+		return new SEFFInterpretationProgressed(seffInterpretationContext);
 	}
 
-	private Result<SEFFInterpretationProgressed> repeat(final SEFFInterpretationContext entity) {
-		return Result.of(new SEFFInterpretationProgressed(entity));
+	private SEFFInterpretationProgressed repeat(final SEFFInterpretationContext entity) {
+		return new SEFFInterpretationProgressed(entity);
 	}
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SystemSimulationBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SystemSimulationBehavior.java
@@ -144,7 +144,7 @@ public class SystemSimulationBehavior implements SimulationBehaviorExtension {
 				Optional.empty());
 		final Set<SEFFInterpretationProgressed> appearedEvents = interpreter.doSwitch(context.getProvidedRole());
 
-		return Result.from(appearedEvents);
+		return Result.of(appearedEvents);
 	}
 
 	/**
@@ -156,7 +156,7 @@ public class SystemSimulationBehavior implements SimulationBehaviorExtension {
 	 * 				now lies in the ResourceSimulation.
 	 */
 	@Deprecated
-	//@Subscribe
+	@Subscribe
 	public Result<SEFFInterpretationProgressed> onRequestInitiated(
 			final SEFFExternalActionCalled requestInitiated) {
 		final GeneralEntryRequest entity = requestInitiated.getEntity();

--- a/org.palladiosimulator.analyzer.slingshot.behavior.usagesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/usagesimulation/UsageSimulationBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.usagesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/usagesimulation/UsageSimulationBehavior.java
@@ -136,7 +136,7 @@ public class UsageSimulationBehavior implements SimulationBehaviorExtension {
 		//assert Postconditions.checkResultTypesAndSize(returnedEvents,
 		//		List.of(UserStarted.class, InterArrivalUserInitiated.class), 2);
 
-		return Result.from(returnedEvents);
+		return Result.of(returnedEvents);
 	}
 
 	/**
@@ -265,7 +265,7 @@ public class UsageSimulationBehavior implements SimulationBehaviorExtension {
 			result.add(new UsageScenarioStarted(userStarted.getEntity(), 0));
 		}
 
-		return Result.from(result);
+		return Result.of(result);
 	}
 
 	/**
@@ -297,7 +297,7 @@ public class UsageSimulationBehavior implements SimulationBehaviorExtension {
 				.findAny()
 				.isEmpty();
 
-		return Result.from(result);
+		return Result.of(result);
 	}
 
 	/**
@@ -362,7 +362,7 @@ public class UsageSimulationBehavior implements SimulationBehaviorExtension {
 			this.finishUserInterpretation(resultSet, context);
 		}
 
-		return Result.from(resultSet);
+		return Result.of(resultSet);
 	}
 
 	/**
@@ -401,7 +401,7 @@ public class UsageSimulationBehavior implements SimulationBehaviorExtension {
 				closedWorkloadUserInitiated.getEntity().getBehaviorContext().getScenarioBehavior());
 		final UsageScenarioInterpreter usageScenarioInterpreter = new UsageScenarioInterpreter(
 				closedWorkloadUserInitiated.getEntity());
-		return Result.from(usageScenarioInterpreter.doSwitch(updatedRootScenarioContext.startScenario()));
+		return Result.of(usageScenarioInterpreter.doSwitch(updatedRootScenarioContext.startScenario()));
 	}
 
 	@Subscribe
@@ -411,7 +411,7 @@ public class UsageSimulationBehavior implements SimulationBehaviorExtension {
 		final UsageScenarioInterpreter usageScenarioInterpreter = new UsageScenarioInterpreter(
 				userInterpretationContext);
 		final Set<DESEvent> events = usageScenarioInterpreter.doSwitch(userInterpretationContext.getCurrentAction());
-		return Result.from(events);
+		return Result.of(events);
 	}
 
 	/**
@@ -426,6 +426,6 @@ public class UsageSimulationBehavior implements SimulationBehaviorExtension {
 	 */
 	private Result<DESEvent> interpretNextAction(final UserInterpretationContext context) {
 		final UsageScenarioInterpreter interpreter = new UsageScenarioInterpreter(context);
-		return Result.from(interpreter.doSwitch(context.getCurrentAction()));
+		return Result.of(interpreter.doSwitch(context.getCurrentAction()));
 	}
 }


### PR DESCRIPTION
I had the idea, that it would be more beautiful to have `Result` only at actual subscribers / subscribtion operations (what ever we call them).

This proposal is an example of what i mean by that. 
Depends on https://github.com/PalladioSimulator/Palladio-Analyzer-Slingshot/pull/5 and won't work without it.

imo, the advantage is the that we can make more fine grained use of static type checking and i *love* static type checking ;)