### PR TITLE
Fix Spawning of Users for multiple UsageScenarios

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.usagesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/usagemodel/events/InterArrivalUserInitiated.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.usagesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/usagemodel/events/InterArrivalUserInitiated.java
@@ -1,23 +1,23 @@
 package org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.events;
 
-import org.palladiosimulator.analyzer.slingshot.common.events.AbstractSimulationEvent;
+import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.entities.interpretationcontext.UserInterpretationContext;
 
 /**
  * Event that is used to initialize a new open workload user after a certain
  * time. The time must be specified in the {@link #getDelay()}.
- * 
+ *
  * @author Julijan Katic
  *
  */
-public final class InterArrivalUserInitiated extends AbstractSimulationEvent {
+public final class InterArrivalUserInitiated extends AbstractUserChangedEvent {
 
 	/**
 	 * Constructs this event with a delay.
-	 * 
+	 *
 	 * @param delay The delay after what a user should be (re-)spawned.
 	 */
-	public InterArrivalUserInitiated(final double delay) {
-		super(delay);
+	public InterArrivalUserInitiated(final UserInterpretationContext entity, final double delay) {
+		super(entity, delay);
 	}
 
 }


### PR DESCRIPTION
## Current Behaviours
the symptoms are twofold, as described in issue #21. 

## New Behaviour 
* Simulator creates the `UserInterpretationContext` for the new user already when creating the `InterArrivalUserinitiated` event. 
* Thus, when the new user arrives, we already have a context.
  - No iteration over all scenarios, no accidental spawning of users for *all* scenarios, only spawning of users for the scenario a new user just arrived at. 
  
## Misc
If putting the context into the interArrivalUserInitiated event violates some design decision, i apologize. However, i could not come up with any alternatives to identify the scenario the initiated user belongs to. 