### PR TITLE
keep parent caller for nested SEFFs

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/entities/seff/SEFFInterpretationContext.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/entities/seff/SEFFInterpretationContext.java
@@ -13,8 +13,12 @@ import com.google.common.base.Preconditions;
 /**
  * The SEFFInterpretationContext is used for keeping track of the RDSeff
  * interpertation.
- * 
- * @author Julijan Katic
+ *
+ * Child contexts (i.e. nested SEFFs) always hold the caller
+ * ({@code calledFrom}) of their parent context. However, only Root behaviours
+ * should return to their callers. Others should return to their parent.
+ *
+ * @author Julijan Katic, Sarah Stieß
  * @version 1.0
  */
 public final class SEFFInterpretationContext {
@@ -67,7 +71,7 @@ public final class SEFFInterpretationContext {
 
 	/**
 	 * Creates builder to build {@link SEFFInterpretationContext}.
-	 * 
+	 *
 	 * @return created builder
 	 */
 	@Generated("SparkTools")

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/entities/seff/behaviorcontext/LoopBehaviorContextHolder.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/entities/seff/behaviorcontext/LoopBehaviorContextHolder.java
@@ -13,7 +13,7 @@ import com.google.common.base.Preconditions;
  * progression of the loop. The loop behavior is considered to be finished as
  * soon as the inner model has finished and the progression reaches the
  * specified loop count.
- * 
+ *
  * @author Julijan Katic
  *
  */
@@ -22,12 +22,12 @@ public final class LoopBehaviorContextHolder extends SingleBehaviorContextHolder
 	private static final Logger LOGGER = Logger.getLogger(LoopBehaviorContextHolder.class);
 
 	private final int maximalLoopCounter;
-	private int progression = 0;
+	private int progression = 1;
 
 	/**
 	 * Instantiates the LoopBehaviorContextHolder. No parameter must be
 	 * {@code null}.
-	 * 
+	 *
 	 * @param behavior           The behavior to interpret.
 	 * @param successor          The successor action after this action.
 	 * @param parent             The model in which the action lies.
@@ -45,7 +45,7 @@ public final class LoopBehaviorContextHolder extends SingleBehaviorContextHolder
 	 * Returns whether the loop behavior has finished. This is only the case if all
 	 * models are finished and the progression has reached the specified loop
 	 * counter.
-	 * 
+	 *
 	 * @return true if each model is finished and the loop counter has been reached.
 	 */
 	@Override

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/entities/seff/behaviorcontext/MultiBehaviorContextHolder.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/entities/seff/behaviorcontext/MultiBehaviorContextHolder.java
@@ -13,7 +13,7 @@ public abstract class MultiBehaviorContextHolder extends SeffBehaviorContextHold
 	protected MultiBehaviorContextHolder(final List<ResourceDemandingBehaviour> behaviors,
 			final Optional<AbstractAction> successor, final Optional<SeffBehaviorWrapper> parent) {
 		super(behaviors, successor, parent);
-		Preconditions.checkArgument(behaviors.size() > 1);
+		Preconditions.checkArgument(behaviors.size() > 0);
 	}
 
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SeffSimulationBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SeffSimulationBehavior.java
@@ -69,8 +69,9 @@ public class SeffSimulationBehavior implements SimulationBehaviorExtension {
 		final SEFFInterpretationContext entity = finished.getEntity();
 		final Result<AbstractSimulationEvent> result;
 		/*
-		 * If the interpretation is finished in a SEFF that was called from another
-		 * SEFF, continue there. Otherwise, the SEFF comes from a User request.
+		 * If the interpretation is finished in a SEFF that was nested into or called
+		 * from another SEFF, continue there. Otherwise, the SEFF comes from a User
+		 * request.
 		 */
 		if (entity.getBehaviorContext() instanceof ForkBehaviorContextHolder) {
 
@@ -89,12 +90,12 @@ public class SeffSimulationBehavior implements SimulationBehaviorExtension {
 		} else if (!entity.getBehaviorContext().hasFinished()) {
 			LOGGER.info("repeat scenario");
 			result = Result.of(this.repeat(entity));
-		} else if (entity.getCaller().isPresent()) {
-			LOGGER.info("return to caller");
-			result = Result.of(this.continueInCaller(entity));
 		} else if (entity.getBehaviorContext().isChild()) {
 			LOGGER.info("return to parent");
 			result = Result.of(this.continueInParent(entity));
+		} else if (entity.getCaller().isPresent()) { // only go to caller, iff it is not a child.
+			LOGGER.info("return to caller");
+			result = Result.of(this.continueInCaller(entity));
 		} else {
 			LOGGER.info("finish request");
 			result = Result.of(this.finishUserRequest(entity));

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/interpreters/SeffInterpreter.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/interpreters/SeffInterpreter.java
@@ -118,6 +118,7 @@ public class SeffInterpreter extends SeffSwitch<Set<SEFFInterpreted>> {
 				this.context.getBehaviorContext().getCurrentProcessedBehavior());
 		final SEFFInterpretationContext childContext = SEFFInterpretationContext.builder().withBehaviorContext(holder)
 				.withRequestProcessingContext(this.context.getRequestProcessingContext())
+				.withCaller(this.context.getCaller())
 				.withAssemblyContext(this.context.getAssemblyContext()).build();
 
 		final SEFFChildInterpretationStarted event = new SEFFChildInterpretationStarted(childContext);
@@ -149,6 +150,7 @@ public class SeffInterpreter extends SeffSwitch<Set<SEFFInterpreted>> {
 				iterationCount);
 		final SEFFInterpretationContext childContext = SEFFInterpretationContext.builder().withBehaviorContext(holder)
 				.withRequestProcessingContext(this.context.getRequestProcessingContext())
+				.withCaller(this.context.getCaller())
 				.withAssemblyContext(this.context.getAssemblyContext()).build();
 
 		return Set.of(new SEFFChildInterpretationStarted(childContext));
@@ -177,6 +179,7 @@ public class SeffInterpreter extends SeffSwitch<Set<SEFFInterpreted>> {
 		final List<SEFFInterpretationContext> childContexts = rdBehaviors.stream()
 				.map(rdBehavior -> SEFFInterpretationContext.builder().withBehaviorContext(forkedBehaviorContext)
 						.withRequestProcessingContext(this.context.getRequestProcessingContext())
+						.withCaller(this.context.getCaller())
 						.withAssemblyContext(this.context.getAssemblyContext()).build())
 				.collect(Collectors.toList());
 


### PR DESCRIPTION
PR for issue #25.

## current behaviour 
Nested SEFFs loose their parent's caller, as described in issue #25.

## new behaviour 
Nested SEFFs keep their parent's caller, and once they parent SEFF is completely interpreted the interpretation continues in the caller. 

## misc
- tested for Loop, Fork (sync) and Branch Actions. Not tested for Iteration Action, as i do not know how to use them. 
- set the lower bound for minimum number of forked behaviours to 1, as i dont see why we need at least 2 of them and SimuLizar allows single forked behaviors as well.
- initialized progression counter for loop behaiours to 1 instead of 0, as the loops are count up to equal to the maximum loop count, thus, if we start at 0, we make one loop iteration too much. 

(if you wanna test it, and need some models, i got some in the `mentor` example repository [over at our gitlab](https://git.rss.iste.uni-stuttgart.de/slingshot/examples/mentorexample/-/branches))