### PR TITLE
Remove "deprecated" annotation

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SystemSimulationBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SystemSimulationBehavior.java
@@ -156,12 +156,7 @@ public class SystemSimulationBehavior implements SimulationBehaviorExtension {
 	/**
 	 * Used to interpret the next SEFF that is requested by another seff. For
 	 * example, when an External Call action was performed.
-	 *
-	 * @deprecated This method does not incooperate linking resources where
-	 * 				the call might actually be hit. Instead, the responsibility
-	 * 				now lies in the ResourceSimulation.
 	 */
-	@Deprecated
 	@Subscribe
 	public Result<SEFFInterpretationProgressed> onRequestInitiated(
 			final SEFFExternalActionCalled requestInitiated) {


### PR DESCRIPTION
This "deprecation" annotation in "onRequestInitiated" is removed.