### PR TITLE
Fix consideration of assembly context for the *assembly* opreation probe.

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/AssemblyOperationCompoundKey.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/AssemblyOperationCompoundKey.java
@@ -1,0 +1,54 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor;
+
+import java.util.Objects;
+
+import org.palladiosimulator.pcm.core.composition.AssemblyContext;
+import org.palladiosimulator.pcm.repository.ProvidedRole;
+
+/**
+ *
+ * Compound Key of AssemblyContext and ProvidedRole, as only the combination of
+ * both uniquely identifies a provided role (defined on component level) of a
+ * specific assembly context.
+ *
+ * @author Sarah Stieß
+ *
+ */
+public final class AssemblyOperationCompoundKey {
+
+	private final AssemblyContext assemblyContext;
+	private final ProvidedRole providedRole;
+
+	private AssemblyOperationCompoundKey(final AssemblyContext resourceContainer, final ProvidedRole providedRole) {
+		this.assemblyContext = resourceContainer;
+		this.providedRole = providedRole;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.assemblyContext.getId(), this.providedRole.getId());
+	}
+
+	@Override
+	public boolean equals(final Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof AssemblyOperationCompoundKey)) {
+			return false;
+		}
+		final AssemblyOperationCompoundKey other = (AssemblyOperationCompoundKey) obj;
+		return Objects.equals(this.assemblyContext.getId(), other.assemblyContext.getId())
+				&& Objects.equals(this.providedRole.getId(), other.providedRole.getId());
+	}
+
+	@Override
+	public String toString() {
+		return this.assemblyContext.getId() + ":" + this.providedRole.getId();
+	}
+
+	public static AssemblyOperationCompoundKey of(final AssemblyContext resourceContainer,
+			final ProvidedRole providedRole) {
+		return new AssemblyOperationCompoundKey(resourceContainer, providedRole);
+	}
+}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/OperationCallActionResponseTimeMonitoringBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/OperationCallActionResponseTimeMonitoringBehavior.java
@@ -64,7 +64,7 @@ import org.palladiosimulator.probeframework.measurement.RequestContext;
 public class OperationCallActionResponseTimeMonitoringBehavior implements SimulationBehaviorExtension {
 
 	private final IGenericCalculatorFactory calculatorFactory;
-	private final Map<String, OperationProbes> userProbesMap = new HashMap<>();
+	private final Map<AssemblyOperationCompoundKey, OperationProbes> userProbesMap = new HashMap<>();
 
 	@Inject
 	public OperationCallActionResponseTimeMonitoringBehavior(final IGenericCalculatorFactory calculatorFactory) {
@@ -90,7 +90,8 @@ public class OperationCallActionResponseTimeMonitoringBehavior implements Simula
 			if (role instanceof OperationProvidedRole) {
 
 				final OperationProbes userProbes = new OperationProbes();
-				this.userProbesMap.put(role.getId(), userProbes);
+				final AssemblyOperationCompoundKey key = AssemblyOperationCompoundKey.of(((AssemblyOperationMeasuringPoint) measuringPoint).getAssembly(), (OperationProvidedRole) role);
+				this.userProbesMap.put(key, userProbes);
 
 				final Calculator calculator = this.calculatorFactory.buildCalculator(
 						MetricDescriptionConstants.RESPONSE_TIME_METRIC_TUPLE, measuringPoint,
@@ -112,9 +113,11 @@ public class OperationCallActionResponseTimeMonitoringBehavior implements Simula
 		}
 
 		final ProvidedRole role = seffStarted.getContext().getRequestProcessingContext().getProvidedRole();
+		final AssemblyOperationCompoundKey key = AssemblyOperationCompoundKey
+				.of(seffStarted.getContext().getAssemblyContext(), role);
 
-		if (role instanceof OperationProvidedRole && this.userProbesMap.containsKey(role.getId())) {
-			final OperationProbes userProbes = this.userProbesMap.get(role.getId());
+		if (role instanceof OperationProvidedRole && this.userProbesMap.containsKey(key)) {
+			final OperationProbes userProbes = this.userProbesMap.get(key);
 			userProbes.operationStartedProbe.takeMeasurement(seffStarted);
 			return Result
 					.of(new ProbeTaken(ProbeTakenEntity.builder().withProbe(userProbes.operationStartedProbe).build()));
@@ -129,9 +132,11 @@ public class OperationCallActionResponseTimeMonitoringBehavior implements Simula
 		}
 
 		final ProvidedRole role = seffFinished.getContext().getRequestProcessingContext().getProvidedRole();
+		final AssemblyOperationCompoundKey key = AssemblyOperationCompoundKey
+				.of(seffFinished.getContext().getAssemblyContext(), role);
 
-		if (role instanceof OperationProvidedRole && this.userProbesMap.containsKey(role.getId())) {
-			final OperationProbes userProbes = this.userProbesMap.get(role.getId());
+		if (role instanceof OperationProvidedRole && this.userProbesMap.containsKey(key)) {
+			final OperationProbes userProbes = this.userProbesMap.get(key);
 			userProbes.operationFinishedProbe.takeMeasurement(seffFinished);
 			return Result.of(
 					new ProbeTaken(ProbeTakenEntity.builder().withProbe(userProbes.operationFinishedProbe).build()));


### PR DESCRIPTION
### Current behaviour:
Monitor only checks the role.
As the role is defined a component level, this kinda of aggregates the measurments of all assemblies providing the same role. 

### New behaviour: 
Introduce a compound key of AssemblyContext and ProvidedRole, to identify measurement per assembyl.

### Misc:
While i was already on it, i also reduced the number of `SEFFModelPassedElement` Event to Start- and StopAction only.  