### PR TITLE
Notice model changes in resource simulation

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/META-INF/MANIFEST.MF
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/META-INF/MANIFEST.MF
@@ -13,7 +13,8 @@ Require-Bundle: org.palladiosimulator.analyzer.slingshot.core;bundle-version="1.
  de.uka.ipd.sdq.simucomframework,
  org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data,
  de.uka.ipd.sdq.simucomframework.variables,
- org.palladiosimulator.analyzer.slingshot.behavior.usagesimulation.data
+ org.palladiosimulator.analyzer.slingshot.behavior.usagesimulation.data,
+ org.palladiosimulator.analyzer.slingshot.behavior.spd.data
 Import-Package: com.google.common.eventbus,
  org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities;version="1.0.0",
  org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events;version="1.0.0",

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/META-INF/MANIFEST.MF
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/META-INF/MANIFEST.MF
@@ -14,7 +14,8 @@ Require-Bundle: org.palladiosimulator.analyzer.slingshot.core;bundle-version="1.
  org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data,
  de.uka.ipd.sdq.simucomframework.variables,
  org.palladiosimulator.analyzer.slingshot.behavior.usagesimulation.data,
- org.palladiosimulator.analyzer.slingshot.behavior.spd.data
+ org.palladiosimulator.analyzer.slingshot.behavior.spd.data,
+ org.eclipse.emf.ecore.xmi
 Import-Package: com.google.common.eventbus,
  org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities;version="1.0.0",
  org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events;version="1.0.0",

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/ResourceSimulation.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/ResourceSimulation.java
@@ -63,7 +63,7 @@ import de.uka.ipd.sdq.simucomframework.variables.StackContext;
 @OnEvent(when = PassiveResourceReleased.class, then = PassiveResourceAcquired.class, cardinality = EventCardinality.MANY)
 @OnEvent(when = ResourceDemandRequested.class, then = { JobInitiated.class,
 		PassiveResourceAcquired.class }, cardinality = SINGLE)
-//@OnEvent(when = ModelAdjusted.class, then = {})
+@OnEvent(when = ModelAdjusted.class, then = {})
 public class ResourceSimulation implements SimulationBehaviorExtension {
 
 	private static final Logger LOGGER = Logger.getLogger(ResourceSimulation.class);

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/ResourceSimulation.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/ResourceSimulation.java
@@ -2,6 +2,10 @@ package org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation;
 
 import static org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.eventcontract.EventCardinality.SINGLE;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.UUID;
@@ -9,6 +13,13 @@ import java.util.UUID;
 import javax.inject.Inject;
 
 import org.apache.log4j.Logger;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceImpl;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.emf.ecore.xmi.XMLResource;
+import org.eclipse.emf.ecore.xmi.impl.XMLResourceFactoryImpl;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.jobs.Job;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.jobs.WaitingJob;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.AbstractJobEvent;
@@ -45,6 +56,8 @@ import org.palladiosimulator.pcm.core.PCMRandomVariable;
 import org.palladiosimulator.pcm.core.composition.AssemblyContext;
 import org.palladiosimulator.pcm.repository.PassiveResource;
 import org.palladiosimulator.pcm.resourceenvironment.LinkingResource;
+import org.palladiosimulator.pcm.resourceenvironment.ResourceEnvironment;
+import org.palladiosimulator.pcm.resourceenvironment.ResourceenvironmentFactory;
 
 import de.uka.ipd.sdq.simucomframework.variables.StackContext;
 
@@ -287,7 +300,39 @@ public class ResourceSimulation implements SimulationBehaviorExtension {
 	 */
 	@Subscribe
 	public void onSimulationFinished(final SimulationFinished simulationFinished) {
+		setupAndSaveResourceModel();
+		
 		this.resourceTable.clearResourcesFromJobs();
 		this.passiveResourceTable.clearResourcesFromJobs();
+	}
+	
+	/*
+	 * Only for debugging!
+	 */
+	private void setupAndSaveResourceModel() {
+		final ResourceSet rs = new ResourceSetImpl();
+		final Resource reResource = createResource("platform:/resource/RemoteMeasuringMosaic/rm_output.resourceenvironment", rs);
+		reResource.getContents().add(allocation.getTargetResourceEnvironment_Allocation());
+		saveResource(reResource);
+	}
+	
+	private Resource createResource(final String outputFile, final ResourceSet rs) { 
+		rs.getResourceFactoryRegistry().getExtensionToFactoryMap().put("resourceenvironment", new XMLResourceFactoryImpl());
+		final URI uri = URI.createURI(outputFile);
+		final Resource resource = rs.createResource(uri);
+		((ResourceImpl) resource).setIntrinsicIDToEObjectMap(new HashMap<>());
+		return resource;
+	}
+	
+	private void saveResource(final Resource resource) {
+		final Map saveOptions = ((XMLResource) resource).getDefaultSaveOptions();
+		saveOptions.put(XMLResource.OPTION_CONFIGURATION_CACHE, Boolean.TRUE);
+		saveOptions.put(XMLResource.OPTION_USE_CACHED_LOOKUP_TABLE, new ArrayList<>());
+		
+		try {
+			resource.save(saveOptions);
+		} catch (final IOException e) {
+			LOGGER.error(e);
+		}
 	}
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/ActiveResourceTable.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/ActiveResourceTable.java
@@ -29,9 +29,8 @@ public final class ActiveResourceTable extends AbstractResourceTable<ActiveResou
 	public void createNewResource(final ResourceContainer container, final ProcessingResourceSpecification spec) {
 		final int numberOfReplicas = spec.getNumberOfReplicas();
 		final SchedulingPolicy schedulingPolicy = spec.getSchedulingPolicy();
-		final ProcessingResourceType activeResourceType = spec.getActiveResourceType_ActiveResourceSpecification();
-
-		final ActiveResourceCompoundKey id = new ActiveResourceCompoundKey(container, activeResourceType);
+		
+		final ActiveResourceCompoundKey id = this.getKey(container, spec);
 
 		final ActiveResource resource;
 		final String resourceName;
@@ -72,9 +71,22 @@ public final class ActiveResourceTable extends AbstractResourceTable<ActiveResou
 				.forEach(this::createActiveResourcesFromResourceContainer);
 	}
 
-	private void createActiveResourcesFromResourceContainer(final ResourceContainer resourceContainer) {
+	public void createActiveResourcesFromResourceContainer(final ResourceContainer resourceContainer) {
 		resourceContainer.getActiveResourceSpecifications_ResourceContainer()
 				.forEach(spec -> this.createNewResource(resourceContainer, spec));
+	}
+	
+	public void removeActiveResources(final ResourceContainer resourceContainer) {
+		resourceContainer.getActiveResourceSpecifications_ResourceContainer().stream()
+						 .map(spec -> this.getKey(resourceContainer, spec))
+						 .filter(id -> this.resources.containsKey(id))
+						 .forEach(id -> this.resources.remove(id));
+	}
+	
+	public ActiveResourceCompoundKey getKey(final ResourceContainer container, final ProcessingResourceSpecification spec) {
+		final ProcessingResourceType activeResourceType = spec.getActiveResourceType_ActiveResourceSpecification();
+		
+		return new ActiveResourceCompoundKey(container, activeResourceType);
 	}
 
 	public Optional<ActiveResource> getActiveResource(final ActiveResourceCompoundKey id) {

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/FCFSResource.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/FCFSResource.java
@@ -14,6 +14,10 @@ import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.even
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.JobProgressed;
 import de.uka.ipd.sdq.probfunction.math.util.MathTools;
 
+
+/*
+ * TODO: Wait on progressing jobs before deleting ~(or JobCancelled)~
+ */
 /**
  * A FCFSResource handles first jobs first, and then the remaining jobs will be
  * handled (first-come, first-served).


### PR DESCRIPTION
- Make the resource simulator aware of model changes and add/delete resource containers
- Initial draft of making resource simulator aware of changes
- make changes noticable
- add util to print all models starting at allocation.
