### PR TITLE
monitor for number of elements in EI

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/META-INF/MANIFEST.MF
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/META-INF/MANIFEST.MF
@@ -15,4 +15,5 @@ Require-Bundle: org.palladiosimulator.analyzer.slingshot.core;bundle-version="1.
  org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data;bundle-version="1.0.0",
  org.palladiosimulator.analyzer.slingshot.monitor;bundle-version="1.0.0",
  org.palladiosimulator.analyzer.slingshot.monitor.utils,
- org.palladiosimulator.analyzer.slingshot.behavior.spd.data;bundle-version="1.0.0"
+ org.palladiosimulator.analyzer.slingshot.behavior.spd.data;bundle-version="1.0.0",
+ org.palladiosimulator.spd.semantic

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/META-INF/MANIFEST.MF
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/META-INF/MANIFEST.MF
@@ -14,4 +14,5 @@ Require-Bundle: org.palladiosimulator.analyzer.slingshot.core;bundle-version="1.
  org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data,
  org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data;bundle-version="1.0.0",
  org.palladiosimulator.analyzer.slingshot.monitor;bundle-version="1.0.0",
- org.palladiosimulator.analyzer.slingshot.monitor.utils
+ org.palladiosimulator.analyzer.slingshot.monitor.utils,
+ org.palladiosimulator.analyzer.slingshot.behavior.spd.data;bundle-version="1.0.0"

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/monitor/NumberOfElementsMonitorBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/monitor/NumberOfElementsMonitorBehavior.java
@@ -1,0 +1,135 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import javax.inject.Inject;
+
+import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.probes.NumberOfElementsInResourceEnvironmentProbe;
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.ModelAdjusted;
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.adjustment.ModelChange;
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.adjustment.ResourceEnvironmentChange;
+import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorExtension;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.Subscribe;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.eventcontract.EventCardinality;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.eventcontract.OnEvent;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
+import org.palladiosimulator.analyzer.slingshot.monitor.data.entities.ProbeTakenEntity;
+import org.palladiosimulator.analyzer.slingshot.monitor.data.events.CalculatorRegistered;
+import org.palladiosimulator.analyzer.slingshot.monitor.data.events.ProbeTaken;
+import org.palladiosimulator.analyzer.slingshot.monitor.data.events.modelvisited.MeasurementSpecificationVisited;
+import org.palladiosimulator.analyzer.slingshot.monitor.data.events.modelvisited.MonitorModelVisited;
+import org.palladiosimulator.edp2.models.measuringpoint.MeasuringPoint;
+import org.palladiosimulator.edp2.util.MetricDescriptionUtility;
+import org.palladiosimulator.metricspec.constants.MetricDescriptionConstants;
+import org.palladiosimulator.monitorrepository.MeasurementSpecification;
+import org.palladiosimulator.pcm.resourceenvironment.ResourceEnvironment;
+import org.palladiosimulator.pcmmeasuringpoint.ResourceEnvironmentMeasuringPoint;
+import org.palladiosimulator.probeframework.calculator.Calculator;
+import org.palladiosimulator.probeframework.calculator.DefaultCalculatorProbeSets;
+import org.palladiosimulator.probeframework.calculator.IGenericCalculatorFactory;
+import org.palladiosimulator.probeframework.probes.Probe;
+
+/**
+ *
+ * Behavior to monitor the number of elements in a Elastic Infrastructure.
+ *
+ *
+ * @author Sarah Stieß
+ *
+ */
+@OnEvent(when = MonitorModelVisited.class, then = CalculatorRegistered.class, cardinality = EventCardinality.SINGLE)
+@OnEvent(when = ModelAdjusted.class, then = ProbeTaken.class, cardinality = EventCardinality.SINGLE)
+public class NumberOfElementsMonitorBehavior implements SimulationBehaviorExtension {
+
+	private final IGenericCalculatorFactory calculatorFactory;
+
+	// we only need this map, when we measure per EI cfg unit (i.e. container based)
+	// or if there are multiple Resource environments (not intended by palladio)
+	private final Map<ResourceEnvironment, Probes> probes = new HashMap<>();
+
+	@Inject
+	public NumberOfElementsMonitorBehavior(final IGenericCalculatorFactory calculatorFactory) {
+		this.calculatorFactory = calculatorFactory;
+	}
+
+	@Subscribe
+	public Result<CalculatorRegistered> onMeasurementSpecification(final MeasurementSpecificationVisited m) {
+		final MeasurementSpecification spec = m.getEntity();
+		final MeasuringPoint measuringPoint = spec.getMonitor().getMeasuringPoint();
+
+		if (measuringPoint instanceof ResourceEnvironmentMeasuringPoint) {
+
+			final ResourceEnvironmentMeasuringPoint resourceEnvironmentMeasuringPoint = (ResourceEnvironmentMeasuringPoint) measuringPoint;
+
+			if (MetricDescriptionUtility.metricDescriptionIdsEqual(spec.getMetricDescription(),
+					MetricDescriptionConstants.NUMBER_OF_RESOURCE_CONTAINERS)) {
+				final Calculator calculator = this.setupNumberOfElementsCalculator(resourceEnvironmentMeasuringPoint,
+						this.calculatorFactory);
+				return Result.of(new CalculatorRegistered(calculator));
+
+			}
+		}
+		return Result.empty();
+	}
+
+	@Subscribe
+	public Result<ProbeTaken> onModelAdjusted(final ModelAdjusted stateUpdated) {
+		final Optional<Probe> probe = this.currentNumberOfElements(stateUpdated);
+		if (probe.isPresent()) {
+			return Result.of(new ProbeTaken(ProbeTakenEntity.builder().withProbe(probe.get()).build()));
+		}
+		return Result.of();
+	}
+
+	/**
+	 * TODO : do we considers multiple Resource environments?
+	 *
+	 * @param event
+	 * @return
+	 */
+	public Optional<Probe> currentNumberOfElements(final ModelAdjusted event) {
+		for (final ModelChange<?> change : event.getChanges()) {
+			if (change instanceof ResourceEnvironmentChange) {
+
+				final ResourceEnvironmentChange resChange = (ResourceEnvironmentChange) change;
+
+				final Probes probes = this.probes
+						.get(resChange.getOldResourceContainers().get(0).getResourceEnvironment_ResourceContainer());
+
+				if (probes != null) {
+					// TODO : get number of containers from config, capsulate into event, to put it
+					// into the Probe o_O
+					// 1. create the respective "fake" event o_O
+					// or : over write tak -- nah, the i gotta over write every thing o_O
+					// can i go by with "just" the elements from the model adjusted?
+					probes.numberOfElementsAtElasticInfrastructure.takeMeasurement(event);
+					return Optional.of(probes.numberOfElementsAtElasticInfrastructure);
+				}
+			}
+		}
+
+		return Optional.empty();
+	}
+
+	public Calculator setupNumberOfElementsCalculator(final ResourceEnvironmentMeasuringPoint measuringPoint,
+			final IGenericCalculatorFactory calculatorFactory) {
+		this.probes.putIfAbsent(measuringPoint.getResourceEnvironment(), new Probes());
+		final Probes probes = this.probes.get(measuringPoint.getResourceEnvironment());
+		return calculatorFactory.buildCalculator(MetricDescriptionConstants.NUMBER_OF_RESOURCE_CONTAINERS_OVER_TIME,
+				measuringPoint, DefaultCalculatorProbeSets
+						.createSingularProbeConfiguration(probes.numberOfElementsAtElasticInfrastructure));
+	}
+
+	/**
+	 *
+	 *
+	 *
+	 * @author Sarah Stieß
+	 *
+	 */
+	private static final class Probes {
+		// create probe.
+		private final NumberOfElementsInResourceEnvironmentProbe numberOfElementsAtElasticInfrastructure = new NumberOfElementsInResourceEnvironmentProbe();
+	}
+}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/monitor/NumberOfElementsMonitorBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/monitor/NumberOfElementsMonitorBehavior.java
@@ -33,23 +33,30 @@ import org.palladiosimulator.probeframework.calculator.DefaultCalculatorProbeSet
 import org.palladiosimulator.probeframework.calculator.IGenericCalculatorFactory;
 import org.palladiosimulator.semanticspd.Configuration;
 import org.palladiosimulator.semanticspd.ElasticInfrastructureCfg;
-import org.palladiosimulator.semanticspd.TargetGroupCfg;
 
 /**
  *
  * Behavior to monitor the number of elements in a Elastic Infrastructure.
  *
  * The behavior creates Probes and Calculators for
- * {@link ResourceEnvironmentMeasuringPoint}s and
- * {@link ResourceContainerMeasuringPoint}s.
+ * {@link ResourceContainerMeasuringPoint}s. Beware it does *not* react to
+ * {@link ResourceEnvironmentMeasuringPoint}s, as we cannot determine the target
+ * group configuration from that measuring point.
  *
  * For a {@link ResourceContainerMeasuringPoint}, the behavior creates a probe
  * and a calculator for the given resource container, iff the resource container
  * is {@code unit} in any of the given target configurations.
  *
- * For a {@link ResourceEnvironmentMeasuringPoint}, the behavior creates probes
- * and calculators for all {@code unit} resource containers in the target
- * configurations.
+ * The metric specification must be the base metric "number of resource
+ * containers".
+ *
+ * Beware : this behaviour is only a temporary workaround. In the future there
+ * should be a afor a target group. In that way the modeller knows that the
+ * measuring point is bound to the concepts that SPD contributes. In the current
+ * way the modeller is unaware that the combination MP on the Resource Container
+ * and the metric Number of Resource Container is valid only when the SPD
+ * extension is active in Slingshot.
+ *
  *
  * @author Sarah Stieß
  *
@@ -80,29 +87,7 @@ public class NumberOfElementsMonitorBehavior implements SimulationBehaviorExtens
 		final MeasurementSpecification spec = m.getEntity();
 		final MeasuringPoint measuringPoint = spec.getMonitor().getMeasuringPoint();
 
-		if (measuringPoint instanceof ResourceEnvironmentMeasuringPoint) {
-			// Env MP --> register probes for all EI
-			final ResourceEnvironmentMeasuringPoint resourceEnvironmentMeasuringPoint = (ResourceEnvironmentMeasuringPoint) measuringPoint;
-
-			if (MetricDescriptionUtility.metricDescriptionIdsEqual(spec.getMetricDescription(),
-					MetricDescriptionConstants.NUMBER_OF_RESOURCE_CONTAINERS)) {
-
-				final Set<CalculatorRegistered> calculators = new HashSet<>();
-
-				for (final TargetGroupCfg cfg : this.semanticConfiguration.getTargetCfgs()) {
-					if (cfg instanceof ElasticInfrastructureCfg) {
-						final Calculator calculator = this.setupNumberOfElementsCalculator(
-								resourceEnvironmentMeasuringPoint, this.calculatorFactory,
-								(ElasticInfrastructureCfg) cfg);
-
-						calculators.add(new CalculatorRegistered(calculator));
-					}
-				}
-
-				return Result.of(calculators);
-
-			}
-		} else if (measuringPoint instanceof ResourceContainerMeasuringPoint) {
+		if (measuringPoint instanceof ResourceContainerMeasuringPoint) {
 			// Container MP --> register probe for EI where container is unit
 			final ResourceContainerMeasuringPoint resourceContainerMeasuringPoint = (ResourceContainerMeasuringPoint) measuringPoint;
 

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/monitor/NumberOfElementsMonitorBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/monitor/NumberOfElementsMonitorBehavior.java
@@ -8,7 +8,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.probes.NumberOfElementsInResourceEnvironmentProbe;
+import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.probes.NumberOfElementsInElasitcInfrastuctureProbe;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.ModelAdjusted;
 import org.palladiosimulator.analyzer.slingshot.common.annotations.Nullable;
 import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorExtension;
@@ -61,7 +61,7 @@ public class NumberOfElementsMonitorBehavior implements SimulationBehaviorExtens
 	private final IGenericCalculatorFactory calculatorFactory;
 	private final Configuration semanticConfiguration;
 
-	private final Map<ResourceContainer, NumberOfElementsInResourceEnvironmentProbe> probes = new HashMap<>();
+	private final Map<ResourceContainer, NumberOfElementsInElasitcInfrastuctureProbe> probes = new HashMap<>();
 
 	@Inject
 	public NumberOfElementsMonitorBehavior(final IGenericCalculatorFactory calculatorFactory,
@@ -130,7 +130,7 @@ public class NumberOfElementsMonitorBehavior implements SimulationBehaviorExtens
 	public Result<ProbeTaken> onModelAdjusted(final ModelAdjusted stateUpdated) {
 		final Set<ProbeTaken> probesTaken = new HashSet<>();
 
-		for (final NumberOfElementsInResourceEnvironmentProbe probe : probes.values()) {
+		for (final NumberOfElementsInElasitcInfrastuctureProbe probe : probes.values()) {
 			probe.takeMeasurement(stateUpdated);
 			probesTaken.add(new ProbeTaken(ProbeTakenEntity.builder().withProbe(probe).build()));
 		}
@@ -146,8 +146,8 @@ public class NumberOfElementsMonitorBehavior implements SimulationBehaviorExtens
 	 */
 	public Calculator setupNumberOfElementsCalculator(final MeasuringPoint measuringPoint,
 			final IGenericCalculatorFactory calculatorFactory, final ElasticInfrastructureCfg eiCfg) {
-		this.probes.putIfAbsent(eiCfg.getUnit(), new NumberOfElementsInResourceEnvironmentProbe(eiCfg));
-		final NumberOfElementsInResourceEnvironmentProbe probe = this.probes.get(eiCfg.getUnit());
+		this.probes.putIfAbsent(eiCfg.getUnit(), new NumberOfElementsInElasitcInfrastuctureProbe(eiCfg));
+		final NumberOfElementsInElasitcInfrastuctureProbe probe = this.probes.get(eiCfg.getUnit());
 		return calculatorFactory.buildCalculator(MetricDescriptionConstants.NUMBER_OF_RESOURCE_CONTAINERS_OVER_TIME,
 				measuringPoint, DefaultCalculatorProbeSets.createSingularProbeConfiguration(probe));
 	}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/monitor/ResourceSimulationMonitorModule.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/monitor/ResourceSimulationMonitorModule.java
@@ -8,6 +8,7 @@ public class ResourceSimulationMonitorModule extends AbstractSlingshotExtension 
 	protected void configure() {
 		install(ActiveResourceMonitorBehavior.class);
 		install(PassiveResourceMonitoringBehavior.class);
+		install(NumberOfElementsMonitorBehavior.class);
 	}
 
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/probes/NumberOfElementsInElasitcInfrastuctureProbe.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/probes/NumberOfElementsInElasitcInfrastuctureProbe.java
@@ -17,7 +17,7 @@ import org.palladiosimulator.semanticspd.ElasticInfrastructureCfg;
  * @author Sarah Stieß
  *
  */
-public final class NumberOfElementsInResourceEnvironmentProbe extends EventBasedListProbe<Long, Dimensionless> {
+public final class NumberOfElementsInElasitcInfrastuctureProbe extends EventBasedListProbe<Long, Dimensionless> {
 
 	private final ElasticInfrastructureCfg elasticInfrastructureConfiguration;
 
@@ -27,7 +27,7 @@ public final class NumberOfElementsInResourceEnvironmentProbe extends EventBased
 	 * @param elasticInfrastructureConfiguration configuration of target group that
 	 *                                           will be measured.
 	 */
-	public NumberOfElementsInResourceEnvironmentProbe(
+	public NumberOfElementsInElasitcInfrastuctureProbe(
 			final ElasticInfrastructureCfg elasticInfrastructureConfiguration) {
 		super(MetricDescriptionConstants.NUMBER_OF_RESOURCE_CONTAINERS_OVER_TIME);
 		// yes, this one subsumes

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/probes/NumberOfElementsInResourceEnvironmentProbe.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/probes/NumberOfElementsInResourceEnvironmentProbe.java
@@ -2,46 +2,41 @@ package org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.pro
 
 import javax.measure.Measure;
 import javax.measure.quantity.Dimensionless;
-import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.ActiveResourceStateUpdated;
-import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.ModelAdjusted;
-import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.adjustment.ResourceEnvironmentChange;
 import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
 import org.palladiosimulator.analyzer.slingshot.monitor.probes.EventBasedListProbe;
 import org.palladiosimulator.metricspec.constants.MetricDescriptionConstants;
+import org.palladiosimulator.semanticspd.ElasticInfrastructureCfg;
 
 /**
+ * Probe for the Number of Elements in a Elastic Infrastructure.
+ *
+ * The Number of Elements is always calculated with regard to a certain target
+ * group configuration, i.e. only elements of a given target group are
+ * aconsidered.
  *
  * @author Sarah Stieß
  *
  */
 public final class NumberOfElementsInResourceEnvironmentProbe extends EventBasedListProbe<Long, Dimensionless> {
 
+	private final ElasticInfrastructureCfg elasticInfrastructureConfiguration;
+
 	/**
-	 * Constructs a StateOfActiveResourceProbe.
+	 * Constructor for NumberOfElementsInResourceEnvironmentProbe.
+	 *
+	 * @param elasticInfrastructureConfiguration configuration of target group that
+	 *                                           will be measured.
 	 */
-	public NumberOfElementsInResourceEnvironmentProbe() {
+	public NumberOfElementsInResourceEnvironmentProbe(
+			final ElasticInfrastructureCfg elasticInfrastructureConfiguration) {
 		super(MetricDescriptionConstants.NUMBER_OF_RESOURCE_CONTAINERS_OVER_TIME);
 		// yes, this one subsumes
+		this.elasticInfrastructureConfiguration = elasticInfrastructureConfiguration;
 	}
 
 	@Override
 	public Measure<Long, Dimensionless> getMeasurement(final DESEvent event) {
-		if (event instanceof ModelAdjusted) {
-
-			final ResourceEnvironmentChange resEnvChange = ((ModelAdjusted) event).getChanges().stream()
-					.filter(change -> (change instanceof ResourceEnvironmentChange))
-					.map(change -> (ResourceEnvironmentChange) change).findAny().orElseGet(() -> {
-						throw new IllegalArgumentException(
-								String.format("Expected an ResourceEnvironmentChange, but found none."));
-					});
-
-			final int numberOfElements = resEnvChange.getOldResourceContainers().size()
-					- resEnvChange.getDeletedResourceContainers().size()
-					+ resEnvChange.getNewResourceContainers().size();
-
-			return Measure.valueOf(Long.valueOf(numberOfElements), Dimensionless.UNIT);
-		}
-		throw new IllegalArgumentException(String.format("Wrong eventype. Expected %s but got %s.",
-				ActiveResourceStateUpdated.class.getSimpleName(), event.getClass().getSimpleName()));
+		return Measure.valueOf(Long.valueOf(elasticInfrastructureConfiguration.getElements().size()),
+				Dimensionless.UNIT);
 	}
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/probes/NumberOfElementsInResourceEnvironmentProbe.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/probes/NumberOfElementsInResourceEnvironmentProbe.java
@@ -1,0 +1,47 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.probes;
+
+import javax.measure.Measure;
+import javax.measure.quantity.Dimensionless;
+import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.ActiveResourceStateUpdated;
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.ModelAdjusted;
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.adjustment.ResourceEnvironmentChange;
+import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
+import org.palladiosimulator.analyzer.slingshot.monitor.probes.EventBasedListProbe;
+import org.palladiosimulator.metricspec.constants.MetricDescriptionConstants;
+
+/**
+ *
+ * @author Sarah Stieß
+ *
+ */
+public final class NumberOfElementsInResourceEnvironmentProbe extends EventBasedListProbe<Long, Dimensionless> {
+
+	/**
+	 * Constructs a StateOfActiveResourceProbe.
+	 */
+	public NumberOfElementsInResourceEnvironmentProbe() {
+		super(MetricDescriptionConstants.NUMBER_OF_RESOURCE_CONTAINERS_OVER_TIME);
+		// yes, this one subsumes
+	}
+
+	@Override
+	public Measure<Long, Dimensionless> getMeasurement(final DESEvent event) {
+		if (event instanceof ModelAdjusted) {
+
+			final ResourceEnvironmentChange resEnvChange = ((ModelAdjusted) event).getChanges().stream()
+					.filter(change -> (change instanceof ResourceEnvironmentChange))
+					.map(change -> (ResourceEnvironmentChange) change).findAny().orElseGet(() -> {
+						throw new IllegalArgumentException(
+								String.format("Expected an ResourceEnvironmentChange, but found none."));
+					});
+
+			final int numberOfElements = resEnvChange.getOldResourceContainers().size()
+					- resEnvChange.getDeletedResourceContainers().size()
+					+ resEnvChange.getNewResourceContainers().size();
+
+			return Measure.valueOf(Long.valueOf(numberOfElements), Dimensionless.UNIT);
+		}
+		throw new IllegalArgumentException(String.format("Wrong eventype. Expected %s but got %s.",
+				ActiveResourceStateUpdated.class.getSimpleName(), event.getClass().getSimpleName()));
+	}
+}


### PR DESCRIPTION
addresses the EI part of #41.

### current behaviour 
no monitoring of number of elements. 

### new behaviour
monitoring for number of elements for EI.
still no monitoring for number of elements in CCG and SG, cause they are more difficult (c.f. notes in #41).

### implementation
probing is triggered by `ModelAdjusted` events. number of elements is calculated based on the `elements` field in the EI target group configuration. 