### PR TITLE
Linking resource

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/entities/jobs/ActiveJob.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/entities/jobs/ActiveJob.java
@@ -11,8 +11,6 @@ import org.palladiosimulator.pcm.allocation.AllocationContext;
 import org.palladiosimulator.pcm.resourceenvironment.ProcessingResourceSpecification;
 import org.palladiosimulator.pcm.resourcetype.ProcessingResourceType;
 
-import de.uka.ipd.sdq.probfunction.math.util.MathTools;
-
 /**
  * A {@link ActiveJob} represents an active resource job that either has to be
  * processed, is being processed or was already processed by the simulator.
@@ -49,16 +47,6 @@ public class ActiveJob extends Job {
 
 	public ResourceDemandRequest getRequest() {
 		return this.request;
-	}
-
-	/**
-	 * Returns whether the job has finished yet. The job is considered finished when
-	 * there is no demand left, i.e. {@code this.getDemand() == 0}.
-	 *
-	 * @return true iff there is no demand left anymore.
-	 */
-	public boolean isFinished() {
-		return MathTools.equalsDouble(this.getDemand(), 0);
 	}
 
 	/**

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/entities/jobs/ActiveJob.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/entities/jobs/ActiveJob.java
@@ -1,0 +1,181 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.jobs;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.annotation.processing.Generated;
+
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.resource.ResourceDemandRequest;
+import org.palladiosimulator.pcm.allocation.AllocationContext;
+import org.palladiosimulator.pcm.resourceenvironment.ProcessingResourceSpecification;
+import org.palladiosimulator.pcm.resourcetype.ProcessingResourceType;
+
+import de.uka.ipd.sdq.probfunction.math.util.MathTools;
+
+/**
+ * A {@link ActiveJob} represents an active resource job that either has to be
+ * processed, is being processed or was already processed by the simulator.
+ * <p>
+ * Two jobs are considered equal if their respective {@link #getId()}s are
+ * equal.
+ * <p>
+ * A job is considered "higher" than another job if it has a higher demand.
+ *
+ * @author Julijan Katic
+ */
+public class ActiveJob extends Job {
+
+	/** The processing resource type that is being requested */
+	private final ProcessingResourceType processingResourceType;
+
+	/** The allocation context where the resource resides. */
+	private final AllocationContext allocationContext;
+
+	/** Keeps track of the resource demand. */
+	private final ResourceDemandRequest request;
+
+	@Generated("SparkTools")
+	private ActiveJob(final Builder builder) {
+		super(builder.id, builder.demand);
+		this.processingResourceType = builder.processingResourceType;
+		this.allocationContext = builder.allocationContext;
+		this.request = builder.request;
+	}
+
+	public ProcessingResourceType getProcessingResourceType() {
+		return EcoreUtil.copy(this.processingResourceType);
+	}
+
+	public ResourceDemandRequest getRequest() {
+		return this.request;
+	}
+
+	/**
+	 * Returns whether the job has finished yet. The job is considered finished when
+	 * there is no demand left, i.e. {@code this.getDemand() == 0}.
+	 *
+	 * @return true iff there is no demand left anymore.
+	 */
+	public boolean isFinished() {
+		return MathTools.equalsDouble(this.getDemand(), 0);
+	}
+
+	/**
+	 * @return the allocationContext
+	 */
+	public AllocationContext getAllocationContext() {
+		return this.allocationContext;
+	}
+
+	/**
+	 * Returns the processing resource specification of the job's resource container
+	 * that also matches the job's processing resource type.
+	 *
+	 * @return the processingResourceSpecification
+	 */
+	public ProcessingResourceSpecification getProcessingResourceSpecification() {
+		final List<ProcessingResourceSpecification> matches = this.allocationContext
+				.getResourceContainer_AllocationContext().getActiveResourceSpecifications_ResourceContainer().stream()
+				.filter(
+				spec -> spec.getActiveResourceType_ActiveResourceSpecification().equals(this.processingResourceType))
+				.collect(Collectors.toList());
+
+		if (matches.size() != 1) {
+			throw new IllegalArgumentException(
+					String.format("Wrong number of matching ProcessingResourceSpecifications, expected 1 but found %d",
+							matches.size()));
+		}
+
+		return matches.get(0);
+	}
+
+	/**
+	 * Creates builder to build {@link ActiveJob}.
+	 *
+	 * @return created builder
+	 */
+	@Generated("SparkTools")
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Builder to build {@link ActiveJob}.
+	 */
+	@Generated("SparkTools")
+	public static final class Builder {
+		private String id;
+		private double demand;
+		private ProcessingResourceType processingResourceType;
+		private AllocationContext allocationContext;
+		private ResourceDemandRequest request;
+
+		private Builder() {
+		}
+
+		/**
+		 * Builder method for id parameter.
+		 *
+		 * @param id field to set
+		 * @return builder
+		 */
+		public Builder withId(final String id) {
+			this.id = id;
+			return this;
+		}
+
+		/**
+		 * Builder method for demand parameter.
+		 *
+		 * @param demand field to set
+		 * @return builder
+		 */
+		public Builder withDemand(final double demand) {
+			this.demand = demand;
+			return this;
+		}
+
+		/**
+		 * Builder method for processingResourceType parameter.
+		 *
+		 * @param processingResourceType field to set
+		 * @return builder
+		 */
+		public Builder withProcessingResourceType(final ProcessingResourceType processingResourceType) {
+			this.processingResourceType = processingResourceType;
+			return this;
+		}
+
+		/**
+		 * Builder method for allocationContext parameter.
+		 *
+		 * @param allocationContext field to set
+		 * @return builder
+		 */
+		public Builder withAllocationContext(final AllocationContext allocationContext) {
+			this.allocationContext = allocationContext;
+			return this;
+		}
+
+		/**
+		 * Builder method for request parameter.
+		 *
+		 * @param request field to set
+		 * @return builder
+		 */
+		public Builder withRequest(final ResourceDemandRequest request) {
+			this.request = request;
+			return this;
+		}
+
+		/**
+		 * Builder method of the builder.
+		 *
+		 * @return built class
+		 */
+		public ActiveJob build() {
+			return new ActiveJob(this);
+		}
+	}
+}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/entities/jobs/Job.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/entities/jobs/Job.java
@@ -1,30 +1,8 @@
 package org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.jobs;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Objects;
 
-import javax.annotation.processing.Generated;
-
-import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.resource.ResourceDemandRequest;
-import org.palladiosimulator.pcm.allocation.AllocationContext;
-import org.palladiosimulator.pcm.resourceenvironment.ProcessingResourceSpecification;
-import org.palladiosimulator.pcm.resourcetype.ProcessingResourceType;
-
-import de.uka.ipd.sdq.probfunction.math.util.MathTools;
-
-/**
- * A {@link Job} represents an active resource job that either has to be
- * processed, is being processed or was already processed by the simulator.
- * <p>
- * Two jobs are considered equal if their respective {@link #getId()}s are
- * equal.
- * <p>
- * A job is considered "higher" than another job if it has a higher demand.
- *
- * @author Julijan Katic
- */
-public class Job {
+public abstract class Job {
 
 	/** The unique id of the job */
 	private final String id;
@@ -32,22 +10,28 @@ public class Job {
 	/** The current demand of this job */
 	private double demand;
 
-	/** The processing resource type that is being requested */
-	private final ProcessingResourceType processingResourceType;
+	public Job(final String id, final double demand) {
+		super();
+		this.id = id;
+		this.demand = demand;
+	}
 
-	/** The allocation context where the resource resides. */
-	private final AllocationContext allocationContext;
+	/**
+	 * Returns the demand that the resource still needs to process.
+	 *
+	 * @return
+	 */
+	public double getDemand() {
+		return demand;
+	}
 
-	/** Keeps track of the resource demand. */
-	private final ResourceDemandRequest request;
-
-	@Generated("SparkTools")
-	private Job(final Builder builder) {
-		this.id = builder.id;
-		this.demand = builder.demand;
-		this.processingResourceType = builder.processingResourceType;
-		this.allocationContext = builder.allocationContext;
-		this.request = builder.request;
+	/**
+	 * Updates the job's demand to a new demand.
+	 *
+	 * @param newDemand The non-negative new demand that needs to be set.
+	 */
+	public void updateDemand(final double demand) {
+		this.demand = demand;
 	}
 
 	/**
@@ -57,92 +41,14 @@ public class Job {
 	 * @return the id of this job.
 	 */
 	public String getId() {
-		return this.id;
+		return id;
 	}
 
-	/**
-	 * Returns the demand that the resource still needs to process.
-	 *
-	 * @return
-	 */
-	public double getDemand() {
-		return this.demand;
-	}
-
-	public ProcessingResourceType getProcessingResourceType() {
-		return EcoreUtil.copy(this.processingResourceType);
-	}
-
-	public ResourceDemandRequest getRequest() {
-		return this.request;
-	}
-
-	/**
-	 * Updates the job's demand to a new demand.
-	 *
-	 * @param newDemand The non-negative new demand that needs to be set.
-	 */
-	public void updateDemand(final double newDemand) {
-		this.demand = newDemand;
-	}
-
-	/**
-	 * Returns whether the job has finished yet. The job is considered finished when
-	 * there is no demand left, i.e. {@code this.getDemand() == 0}.
-	 *
-	 * @return true iff there is no demand left anymore.
-	 */
-	public boolean isFinished() {
-		return MathTools.equalsDouble(this.demand, 0);
-	}
-
-	/**
-	 * @return the allocationContext
-	 */
-	public AllocationContext getAllocationContext() {
-		return this.allocationContext;
-	}
-
-	/**
-	 * Returns the processing resource specification of the job's resource container
-	 * that also matches the job's processing resource type.
-	 *
-	 * @return the processingResourceSpecification
-	 */
-	public ProcessingResourceSpecification getProcessingResourceSpecification() {
-		final List<ProcessingResourceSpecification> matches = this.allocationContext
-				.getResourceContainer_AllocationContext().getActiveResourceSpecifications_ResourceContainer().stream()
-				.filter(
-				spec -> spec.getActiveResourceType_ActiveResourceSpecification().equals(this.processingResourceType))
-				.collect(Collectors.toList());
-
-		if (matches.size() != 1) {
-			throw new IllegalArgumentException(
-					String.format("Wrong number of matching ProcessingResourceSpecifications, expected 1 but found %d",
-							matches.size()));
-		}
-
-		return matches.get(0);
-	}
-
-	/**
-	 * Returns the hash code of {@link #getId()}.
-	 *
-	 * @generated
-	 */
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((this.id == null) ? 0 : this.id.hashCode());
-		return result;
+		return Objects.hash(id);
 	}
 
-	/**
-	 * Checks if two Jobs have the same {@link #getId()}.
-	 *
-	 * @generated
-	 */
 	@Override
 	public boolean equals(final Object obj) {
 		if (this == obj) {
@@ -151,111 +57,16 @@ public class Job {
 		if (obj == null) {
 			return false;
 		}
-		if (this.getClass() != obj.getClass()) {
+		if (getClass() != obj.getClass()) {
 			return false;
 		}
 		final Job other = (Job) obj;
-		if (this.id == null) {
-			if (other.id != null) {
-				return false;
-			}
-		} else if (!this.id.equals(other.id)) {
-			return false;
-		}
-		return true;
+		return Objects.equals(id, other.id);
 	}
 
 	@Override
 	public String toString() {
-		return String.format("Job[%s]: %f (Demand)", this.id, this.demand);
+		return "Job [id=" + id + ", demand=" + demand + "]";
 	}
 
-	/**
-	 * Creates builder to build {@link Job}.
-	 *
-	 * @return created builder
-	 */
-	@Generated("SparkTools")
-	public static Builder builder() {
-		return new Builder();
-	}
-
-	/**
-	 * Builder to build {@link Job}.
-	 */
-	@Generated("SparkTools")
-	public static final class Builder {
-		private String id;
-		private double demand;
-		private ProcessingResourceType processingResourceType;
-		private AllocationContext allocationContext;
-		private ResourceDemandRequest request;
-
-		private Builder() {
-		}
-
-		/**
-		 * Builder method for id parameter.
-		 *
-		 * @param id field to set
-		 * @return builder
-		 */
-		public Builder withId(final String id) {
-			this.id = id;
-			return this;
-		}
-
-		/**
-		 * Builder method for demand parameter.
-		 *
-		 * @param demand field to set
-		 * @return builder
-		 */
-		public Builder withDemand(final double demand) {
-			this.demand = demand;
-			return this;
-		}
-
-		/**
-		 * Builder method for processingResourceType parameter.
-		 *
-		 * @param processingResourceType field to set
-		 * @return builder
-		 */
-		public Builder withProcessingResourceType(final ProcessingResourceType processingResourceType) {
-			this.processingResourceType = processingResourceType;
-			return this;
-		}
-
-		/**
-		 * Builder method for allocationContext parameter.
-		 *
-		 * @param allocationContext field to set
-		 * @return builder
-		 */
-		public Builder withAllocationContext(final AllocationContext allocationContext) {
-			this.allocationContext = allocationContext;
-			return this;
-		}
-
-		/**
-		 * Builder method for request parameter.
-		 *
-		 * @param request field to set
-		 * @return builder
-		 */
-		public Builder withRequest(final ResourceDemandRequest request) {
-			this.request = request;
-			return this;
-		}
-
-		/**
-		 * Builder method of the builder.
-		 *
-		 * @return built class
-		 */
-		public Job build() {
-			return new Job(this);
-		}
-	}
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/entities/jobs/Job.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/entities/jobs/Job.java
@@ -2,6 +2,8 @@ package org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.ent
 
 import java.util.Objects;
 
+import de.uka.ipd.sdq.probfunction.math.util.MathTools;
+
 public abstract class Job {
 
 	/** The unique id of the job */
@@ -42,6 +44,16 @@ public abstract class Job {
 	 */
 	public String getId() {
 		return id;
+	}
+
+	/**
+	 * Returns whether the job has finished yet. The job is considered finished when
+	 * there is no demand left, i.e. {@code this.getDemand() == 0}.
+	 *
+	 * @return true iff there is no demand left anymore.
+	 */
+	public boolean isFinished() {
+		return MathTools.equalsDouble(this.getDemand(), 0);
 	}
 
 	@Override

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/entities/jobs/LinkingJob.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/entities/jobs/LinkingJob.java
@@ -1,18 +1,25 @@
 package org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.jobs;
 
+import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.resource.CallOverWireRequest;
 import org.palladiosimulator.pcm.resourceenvironment.LinkingResource;
 
 public class LinkingJob extends Job {
 
 	private final LinkingResource linkingResource;
+	private final CallOverWireRequest request;
 
-	public LinkingJob(final String id, final double demand, final LinkingResource linkingResource) {
+	public LinkingJob(final String id, final double demand, final LinkingResource linkingResource,
+			final CallOverWireRequest request) {
 		super(id, demand);
 		this.linkingResource = linkingResource;
+		this.request = request;
 	}
 
 	public LinkingResource getLinkingResource() {
 		return linkingResource;
 	}
 
+	public CallOverWireRequest getRequest() {
+		return request;
+	}
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/entities/jobs/LinkingJob.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/entities/jobs/LinkingJob.java
@@ -1,0 +1,18 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.jobs;
+
+import org.palladiosimulator.pcm.resourceenvironment.LinkingResource;
+
+public class LinkingJob extends Job {
+
+	private final LinkingResource linkingResource;
+
+	public LinkingJob(final String id, final double demand, final LinkingResource linkingResource) {
+		super(id, demand);
+		this.linkingResource = linkingResource;
+	}
+
+	public LinkingResource getLinkingResource() {
+		return linkingResource;
+	}
+
+}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/events/AbstractJobEvent.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/events/AbstractJobEvent.java
@@ -1,11 +1,12 @@
 package org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events;
 
+import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.jobs.ActiveJob;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.jobs.Job;
 import org.palladiosimulator.analyzer.slingshot.common.events.AbstractEntityChangedEvent;
 
 /**
  * This abstract class is designed for events that notify a change in the
- * {@link Job} entity.
+ * {@link ActiveJob} entity.
  * 
  * @author Julijan Katic
  */

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/events/ActiveResourceStateUpdated.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/events/ActiveResourceStateUpdated.java
@@ -13,8 +13,8 @@ public final class ActiveResourceStateUpdated extends AbstractJobEvent {
 	private final long requestsAtResource;
 	private final double utilization;
 
-	public ActiveResourceStateUpdated(final Job entity, final long requestsAtResource, final double utilization) {
-		super(entity, 0.0);
+	public ActiveResourceStateUpdated(final Job job, final long requestsAtResource, final double utilization) {
+		super(job, 0.0);
 		this.requestsAtResource = requestsAtResource;
 		this.utilization = utilization;
 	}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/events/JobAborted.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/events/JobAborted.java
@@ -1,0 +1,48 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events;
+
+import java.util.Optional;
+
+import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.jobs.Job;
+
+/**
+ * Tells that the Job has been aborted. Unlike {@link JobFinished}, this signals
+ * that there might have been an error and should be retried.
+ * 
+ * @author Julijan Katic
+ */
+public class JobAborted extends AbstractJobEvent {
+
+	private final Optional<Throwable> exception;
+	private final String reason;
+
+	public JobAborted(final Job entity, final double delay, final Throwable exception, final String reason) {
+		super(entity, delay);
+		this.exception = Optional.ofNullable(exception);
+		this.reason = reason;
+	}
+
+	public JobAborted(final Job entity, final double delay, final String reason) {
+		this(entity, delay, null, reason);
+	}
+
+	public JobAborted(final Job entity, final double delay, final Throwable exception) {
+		this(entity, delay, exception, null);
+	}
+
+	public JobAborted(final Job entity, final double delay) {
+		this(entity, delay, null, null);
+	}
+
+	public Optional<Throwable> getException() {
+		return this.exception;
+	}
+
+	public String getReason() {
+		if (reason == null) {
+			return this.exception.map(Throwable::getMessage).orElse("");
+		}
+
+		return reason;
+	}
+
+}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/events/JobScheduled.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/events/JobScheduled.java
@@ -1,6 +1,6 @@
 package org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events;
 
-import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.jobs.Job;
+import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.jobs.ActiveJob;
 import org.palladiosimulator.analyzer.slingshot.common.events.AbstractEntityChangedEvent;
 
 /**
@@ -8,9 +8,9 @@ import org.palladiosimulator.analyzer.slingshot.common.events.AbstractEntityChan
  * 
  * @author Julijan Katic
  */
-public final class JobScheduled extends AbstractEntityChangedEvent<Job> {
+public final class JobScheduled extends AbstractEntityChangedEvent<ActiveJob> {
 
-	public JobScheduled(final Job entity, final double delay) {
+	public JobScheduled(final ActiveJob entity, final double delay) {
 		super(entity, delay);
 		// TODO Auto-generated constructor stub
 	}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/events/ProcessorSharingJobProgressed.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/events/ProcessorSharingJobProgressed.java
@@ -8,8 +8,8 @@ public final class ProcessorSharingJobProgressed extends JobProgressed {
 
 	private final UUID expectedState;
 
-	public ProcessorSharingJobProgressed(final Job entity, final double delay, final UUID expectedState) {
-		super(entity, delay);
+	public ProcessorSharingJobProgressed(final Job shortestJob, final double delay, final UUID expectedState) {
+		super(shortestJob, delay);
 		this.expectedState = expectedState;
 	}
 

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/events/ResourceDemandCalculated.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/events/ResourceDemandCalculated.java
@@ -12,8 +12,8 @@ public final class ResourceDemandCalculated extends AbstractJobEvent {
 
 	private final double calculatedResourceDemand;
 
-	public ResourceDemandCalculated(final Job entity, final double calculatedResourceDemand) {
-		super(entity, 0.0);
+	public ResourceDemandCalculated(final Job job, final double calculatedResourceDemand) {
+		super(job, 0.0);
 		this.calculatedResourceDemand = calculatedResourceDemand;
 	}
 

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/monitor/ActiveResourceProbeTable.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/monitor/ActiveResourceProbeTable.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.jobs.ActiveJob;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.ActiveResourceStateUpdated;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.ResourceDemandCalculated;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.probes.ResourceDemandRequestedProbe;
@@ -36,22 +37,27 @@ public final class ActiveResourceProbeTable {
 	}
 
 	public Set<Probe> currentStateAndUtilizationOfActiveResource(final ActiveResourceStateUpdated event) {
-		final Probes probes = this.probes
-				.get(event.getEntity().getProcessingResourceSpecification());
-		if (probes != null) {
-			probes.stateOfActiveResourceProbe.takeMeasurement(event);
-			probes.utilizationOfActiveResourceProbe.takeMeasurement(event);
-			return Set.of(probes.stateOfActiveResourceProbe, probes.utilizationOfActiveResourceProbe);
+		if (event.getEntity() instanceof ActiveJob) {
+			final ActiveJob activeJob = (ActiveJob) event.getEntity();
+			final Probes probes = this.probes.get(activeJob.getProcessingResourceSpecification());
+			if (probes != null) {
+				probes.stateOfActiveResourceProbe.takeMeasurement(event);
+				probes.utilizationOfActiveResourceProbe.takeMeasurement(event);
+				return Set.of(probes.stateOfActiveResourceProbe, probes.utilizationOfActiveResourceProbe);
+			}
 		}
+
 		return Set.of();
 	}
 
 	public Optional<Probe> currentResourceDemand(final ResourceDemandCalculated event) {
-		final Probes probes = this.probes
-				.get(event.getEntity().getProcessingResourceSpecification());
-		if (probes != null) {
-			probes.resourceDemandProbe.takeMeasurement(event);
-			return Optional.of(probes.resourceDemandProbe);
+		if (event.getEntity() instanceof ActiveJob) {
+			final ActiveJob activeJob = (ActiveJob) event.getEntity();
+			final Probes probes = this.probes.get(activeJob.getProcessingResourceSpecification());
+			if (probes != null) {
+				probes.resourceDemandProbe.takeMeasurement(event);
+				return Optional.of(probes.resourceDemandProbe);
+			}
 		}
 		return Optional.empty();
 	}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/probes/ResourceDemandRequestedProbe.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/probes/ResourceDemandRequestedProbe.java
@@ -17,6 +17,8 @@ import org.palladiosimulator.metricspec.constants.MetricDescriptionConstants;
  * resource demand as a "[..] (resource demand, point in time)-tuple, [..]",
  * which is upside down compared to all other metric set descriptions.
  *
+ * This now take care of in the parent class. (Probably)
+ *
  * @author Sarah Stieß
  *
  */
@@ -29,19 +31,8 @@ public final class ResourceDemandRequestedProbe extends EventBasedListProbe<Doub
 		super(MetricDescriptionConstants.RESOURCE_DEMAND_METRIC_TUPLE);
 	}
 
-	/**
-	 * Is actually getTime
-	 */
 	@Override
 	public Measure<Double, Duration> getMeasurement(final DESEvent event) {
-		return Measure.valueOf(event.time(), SI.SECOND);
-	}
-
-	/**
-	 * Is actually getMeasurement
-	 */
-	@Override
-	public Measure<Double, Duration> getTime(final DESEvent event) {
 		if (event instanceof ResourceDemandCalculated) {
 			return Measure.valueOf(((ResourceDemandCalculated) event).getResourceDemandRequested(), SI.SECOND);
 		}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/ResourceSimulation.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/ResourceSimulation.java
@@ -317,6 +317,7 @@ public class ResourceSimulation implements SimulationBehaviorExtension {
 		return Result.empty();
 	}
 
+	@Subscribe
 	public Result<?> onJobAborted(final JobAborted aborted) {
 		if (aborted.getEntity() instanceof LinkingJob) {
 			final LinkingJob linkingJob = (LinkingJob) aborted.getEntity();

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/ResourceSimulation.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/ResourceSimulation.java
@@ -389,7 +389,7 @@ public class ResourceSimulation implements SimulationBehaviorExtension {
 	 */
 	private LinkingJob createLinkingJobFromResource(final LinkingResource linkingResource, final User user,
 			final CallOverWireRequest request) {
-		final double demand = user.getStack().currentStackFrame().getContents().stream()
+		final double demand = request.getVariablesToConsider().getContents().stream()
 				.filter(entry -> entry.getKey().endsWith("BYTESIZE"))
 				.mapToDouble(entry -> NumberConverter.toDouble(entry.getValue())).sum();
 

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/AbstractResourceTable.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/AbstractResourceTable.java
@@ -2,6 +2,7 @@ package org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.res
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.resources.IResource;
 
@@ -15,5 +16,9 @@ public abstract class AbstractResourceTable<K, R extends IResource> {
 
 	public void clearResourcesFromJobs() {
 		this.resources.values().forEach(IResource::clearJobs);
+	}
+
+	public Optional<R> getResourceById(final K id) {
+		return Optional.ofNullable(resources.get(id));
 	}
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/AbstractActiveResource.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/AbstractActiveResource.java
@@ -81,6 +81,14 @@ public abstract class AbstractActiveResource extends AbstractResource implements
 	protected abstract ActiveResourceStateUpdated publishState(final Job job);
 
 	/**
+	 * Instructs that a job should be aborted (and thus removed from the queue)
+	 * safely.
+	 * 
+	 * @param job The job to abort.
+	 */
+	protected abstract void abortJob(final Job job);
+
+	/**
 	 * Checks whether the job belongs to the resource. This is done by checking
 	 * whether the {@link ProcessingResourceType} specified in the {@link job} and
 	 * this id ({@link #getId()}) are equal.

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/AbstractActiveResource.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/AbstractActiveResource.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.apache.log4j.Logger;
+import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.jobs.ActiveJob;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.jobs.Job;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.resources.ProcessingRate;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.AbstractJobEvent;
@@ -17,7 +18,7 @@ import org.palladiosimulator.pcm.resourcetype.ProcessingResourceType;
 
 /**
  * The abstract super class of every active resource. It provides a method to
- * check whether a {@link Job} belongs to this instance of resource.
+ * check whether a {@link ActiveJob} belongs to this instance of resource.
  * <p>
  * This abstract already overrides the {@link #onJobInitiated(JobInitiated)}
  * handler by checking whether the job belongs to this instance. If so, then the
@@ -51,7 +52,7 @@ public abstract class AbstractActiveResource extends AbstractResource implements
 
 	/**
 	 * The delegated handler of the resource that will be processed if the job
-	 * belongs to this resource according to {@link #jobBelongsToResource(Job)}
+	 * belongs to this resource according to {@link #jobBelongsToResource(ActiveJob)}
 	 * implementation.
 	 *
 	 * @param jobInitiated The event.
@@ -61,7 +62,7 @@ public abstract class AbstractActiveResource extends AbstractResource implements
 
 	/**
 	 * The delegated handler of the resource that will be processed if the job
-	 * belongs to this resource according to {@link #jobBelongsToResource(Job)}
+	 * belongs to this resource according to {@link #jobBelongsToResource(ActiveJob)}
 	 * implementation.
 	 *
 	 * @param jobProgressed The event.
@@ -96,10 +97,16 @@ public abstract class AbstractActiveResource extends AbstractResource implements
 	 * @param job The job to check.
 	 * @return true if the job belongs to this resource.
 	 */
-	protected boolean jobBelongsToResource(final Job job) {
-		final ActiveResourceCompoundKey jobId = ActiveResourceCompoundKey.of(
-				job.getAllocationContext().getResourceContainer_AllocationContext(), job.getProcessingResourceType());
-		return this.getId().equals(jobId);
+	@Override
+	public boolean jobBelongsToResource(final Job job) {
+		if (job instanceof ActiveJob) {
+			final ActiveJob activeJob = (ActiveJob) job;
+			final ActiveResourceCompoundKey jobId = ActiveResourceCompoundKey.of(
+					activeJob.getAllocationContext().getResourceContainer_AllocationContext(),
+					activeJob.getProcessingResourceType());
+			return this.getId().equals(jobId);
+		}
+		return false;
 	}
 
 	@Override

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/AbstractActiveResource.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/AbstractActiveResource.java
@@ -45,7 +45,7 @@ public abstract class AbstractActiveResource extends AbstractResource implements
 	 * @param capacity The maximum capacity of the resource.
 	 * @param rate     The specified PCM processing rate of the resource.
 	 */
-	public AbstractActiveResource(final ActiveResourceCompoundKey id, final String name, final long capacity, final ProcessingRate rate) {
+	public AbstractActiveResource(final Object id, final String name, final long capacity, final ProcessingRate rate) {
 		super(capacity, name, id);
 		this.processingRate = rate;
 	}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/ActiveResource.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/ActiveResource.java
@@ -2,6 +2,7 @@ package org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.res
 
 import java.util.Set;
 
+import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.jobs.Job;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.resources.IResource;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.AbstractJobEvent;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.JobFinished;
@@ -36,5 +37,7 @@ public interface ActiveResource extends IResource {
 	 * @return the appropriate events for the active resource.
 	 */
 	Set<AbstractJobEvent> onJobProgressed(final JobProgressed jobProgressed);
+
+	boolean jobBelongsToResource(final Job job);
 
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/ActiveResourceTable.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/ActiveResourceTable.java
@@ -65,6 +65,7 @@ public final class ActiveResourceTable extends AbstractResourceTable<ActiveResou
 		}
 	}
 
+
 	public void buildModel(final Allocation allocation) {
 		allocation.getAllocationContexts_Allocation().stream()
 				.map(AllocationContext::getResourceContainer_AllocationContext)

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/FCFSResource.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/FCFSResource.java
@@ -12,6 +12,7 @@ import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.even
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.JobFinished;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.JobInitiated;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.JobProgressed;
+
 import de.uka.ipd.sdq.probfunction.math.util.MathTools;
 
 
@@ -91,6 +92,11 @@ public class FCFSResource extends AbstractActiveResource {
 	@Override
 	public void clearJobs() {
 		this.processes.clear();
+	}
+
+	@Override
+	public void abortJob(final Job job) {
+		this.processes.remove(job);
 	}
 
 	/**

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/FCFSResource.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/FCFSResource.java
@@ -43,7 +43,7 @@ public class FCFSResource extends AbstractActiveResource {
 	 * @param name     The name of the resource.
 	 * @param capacity The maximum capacity of the resource.
 	 */
-	public FCFSResource(final ActiveResourceCompoundKey type, final String name, final long capacity, final ProcessingRate rate) {
+	public FCFSResource(final Object type, final String name, final long capacity, final ProcessingRate rate) {
 		super(type, name, capacity, rate);
 	}
 

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/ProcessorSharingResource.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/active/ProcessorSharingResource.java
@@ -17,6 +17,7 @@ import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.even
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.JobInitiated;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.JobProgressed;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.ProcessorSharingJobProgressed;
+
 import de.uka.ipd.sdq.probfunction.math.util.MathTools;
 
 /**
@@ -121,6 +122,12 @@ public final class ProcessorSharingResource extends AbstractActiveResource {
 			return Set.of(new JobFinished(shortestJob), next.get());
 		}
 		return Set.of(new JobFinished(shortestJob));
+	}
+
+	@Override
+	public void abortJob(final Job job) {
+		this.runningJobs.remove(job);
+		this.reportCoreUsage();
 	}
 
 	@Override

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/linking/LinkingResourceTable.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/linking/LinkingResourceTable.java
@@ -1,9 +1,43 @@
 package org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.resources.linking;
 
-public class LinkingResourceTable {
+import java.util.List;
+import java.util.stream.Collectors;
 
-	public LinkingResourceTable() {
-		// TODO Auto-generated constructor stub
+import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.resources.AbstractResourceTable;
+import org.palladiosimulator.pcm.allocation.Allocation;
+import org.palladiosimulator.pcm.resourceenvironment.LinkingResource;
+import org.palladiosimulator.pcm.resourceenvironment.ResourceContainer;
+
+/**
+ * This table holds all the references to the linking resources, as well as the
+ * ability to find the linking resource between two resource containers.
+ * 
+ * @author Julijan Katic
+ */
+public class LinkingResourceTable extends AbstractResourceTable<String, SimulatedLinkingResource> {
+
+	public void buildTable(final Allocation allocation) {
+		allocation.getTargetResourceEnvironment_Allocation().getLinkingResources__ResourceEnvironment()
+				.forEach(this::createSimulatedLinkingResource);
+	}
+
+	public void createSimulatedLinkingResource(final LinkingResource linkingResource) {
+		this.resources.put(linkingResource.getId(), new SimulatedLinkingResource(linkingResource));
+	}
+
+	public List<SimulatedLinkingResource> findLinkingResourceBetweenContainers(final ResourceContainer from, final ResourceContainer to) {
+		return this.resources.values().stream()
+				.filter(lk -> isConnectedBy(from, to, lk.getLinkingResource()))
+				.collect(Collectors.toList());
+	}
+
+	private boolean isConnectedBy(final ResourceContainer from, final ResourceContainer to, final LinkingResource linkingResource) {
+		return containerInLinkingResource(from, linkingResource) && containerInLinkingResource(to, linkingResource);
+	}
+
+	private boolean containerInLinkingResource(final ResourceContainer rc, final LinkingResource linkingResource) {
+		return linkingResource.getConnectedResourceContainers_LinkingResource().stream()
+				.anyMatch(r -> r.getId().equals(rc.getId()));
 	}
 
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/linking/LinkingResourceTable.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/linking/LinkingResourceTable.java
@@ -1,0 +1,9 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.resources.linking;
+
+public class LinkingResourceTable {
+
+	public LinkingResourceTable() {
+		// TODO Auto-generated constructor stub
+	}
+
+}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/linking/SimulatedLinkingResource.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/linking/SimulatedLinkingResource.java
@@ -41,6 +41,7 @@ public class SimulatedLinkingResource extends FCFSResource {
 		LOGGER.info("Initiate linking job of id " + linkingJob.getId() + " in the resource " + this.getId()
 				+ " of demand " + linkingJob.getDemand());
 
+		linkingJob.updateDemand(linkingJob.getDemand() + latency.calculateRV());
 		return super.onJobInitiated(jobInitiated);
 	}
 
@@ -57,7 +58,7 @@ public class SimulatedLinkingResource extends FCFSResource {
 					ranNumber, this.failureRate)));
 		}
 
-		job.updateDemand(job.getDemand() + latency.calculateRV());
+
 		return super.onJobProgressed(jobProgressed);
 	}
 

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/linking/SimulatedLinkingResource.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/linking/SimulatedLinkingResource.java
@@ -1,5 +1,6 @@
 package org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.resources.linking;
 
+import java.util.Optional;
 import java.util.Set;
 
 import org.apache.log4j.Logger;
@@ -35,14 +36,16 @@ public class SimulatedLinkingResource extends FCFSResource {
 		this.failureRate = spec.getFailureProbability();
 	}
 
-	@Override
-	public Set<AbstractJobEvent> onJobInitiated(final JobInitiated jobInitiated) {
-		final LinkingJob linkingJob = (LinkingJob) jobInitiated.getEntity();
-		LOGGER.info("Initiate linking job of id " + linkingJob.getId() + " in the resource " + this.getId()
-				+ " of demand " + linkingJob.getDemand());
 
-		linkingJob.updateDemand(linkingJob.getDemand() + latency.calculateRV());
-		return super.onJobInitiated(jobInitiated);
+
+	@Override
+	protected Optional<AbstractJobEvent> process(final JobInitiated jobInitiated) {
+		/*
+		 * Note that here, according to FCFS, this event already considers the
+		 * throughput
+		 */
+		jobInitiated.getEntity().updateDemand(jobInitiated.getEntity().getDemand() + latency.calculateRV());
+		return super.process(jobInitiated);
 	}
 
 	@Override

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/linking/SimulatedLinkingResource.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/linking/SimulatedLinkingResource.java
@@ -2,11 +2,13 @@ package org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.res
 
 import java.util.Set;
 
+import org.apache.log4j.Logger;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.jobs.Job;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.jobs.LinkingJob;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.resources.ProcessingRate;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.AbstractJobEvent;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.JobAborted;
+import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.JobInitiated;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.JobProgressed;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.resources.active.FCFSResource;
 import org.palladiosimulator.pcm.resourceenvironment.CommunicationLinkResourceSpecification;
@@ -14,12 +16,14 @@ import org.palladiosimulator.pcm.resourceenvironment.LinkingResource;
 
 public class SimulatedLinkingResource extends FCFSResource {
 
+	private static final Logger LOGGER = Logger.getLogger(SimulatedLinkingResource.class);
+
 	private final ProcessingRate latency;
 	private final double failureRate;
 	private final LinkingResource linkingResource;
 
 	public SimulatedLinkingResource(final LinkingResource linkingResource) {
-		super(null, linkingResource.getEntityName(), 1, new ProcessingRate(linkingResource
+		super(linkingResource.getId(), linkingResource.getEntityName(), 1, new ProcessingRate(linkingResource
 				.getCommunicationLinkResourceSpecifications_LinkingResource()
 				.getThroughput_CommunicationLinkResourceSpecification()));
 		
@@ -29,6 +33,15 @@ public class SimulatedLinkingResource extends FCFSResource {
 		this.linkingResource = linkingResource;
 		this.latency = new ProcessingRate(spec.getLatency_CommunicationLinkResourceSpecification());
 		this.failureRate = spec.getFailureProbability();
+	}
+
+	@Override
+	public Set<AbstractJobEvent> onJobInitiated(final JobInitiated jobInitiated) {
+		final LinkingJob linkingJob = (LinkingJob) jobInitiated.getEntity();
+		LOGGER.info("Initiate linking job of id " + linkingJob.getId() + " in the resource " + this.getId()
+				+ " of demand " + linkingJob.getDemand());
+
+		return super.onJobInitiated(jobInitiated);
 	}
 
 	@Override

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/linking/SimulatedLinkingResource.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/linking/SimulatedLinkingResource.java
@@ -1,0 +1,63 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.resources.linking;
+
+import java.util.Set;
+
+import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.jobs.Job;
+import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.resources.ProcessingRate;
+import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.AbstractJobEvent;
+import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.JobAborted;
+import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.JobInitiated;
+import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.JobProgressed;
+import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.resources.AbstractResource;
+import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.resources.active.ActiveResource;
+import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.resources.active.FCFSResource;
+import org.palladiosimulator.pcm.resourceenvironment.CommunicationLinkResourceSpecification;
+import org.palladiosimulator.pcm.resourceenvironment.LinkingResource;
+
+public class SimulatedLinkingResource extends AbstractResource implements ActiveResource {
+
+	private final ProcessingRate latency;
+	private final ProcessingRate throughput;
+	private final double failureRate;
+	private final FCFSResource underlyingResource;
+
+	public SimulatedLinkingResource(final String name, final LinkingResource linkingResource) {
+		super(1, name, linkingResource.getId());
+
+		final CommunicationLinkResourceSpecification spec = linkingResource
+				.getCommunicationLinkResourceSpecifications_LinkingResource();
+
+		this.latency = new ProcessingRate(spec.getLatency_CommunicationLinkResourceSpecification());
+		this.failureRate = spec.getFailureProbability();
+		this.throughput = new ProcessingRate(spec.getThroughput_CommunicationLinkResourceSpecification());
+		this.underlyingResource = new FCFSResource(null, name, 1, throughput);
+	}
+
+	@Override
+	public void clearJobs() {
+		underlyingResource.clearJobs();
+	}
+
+	@Override
+	public Set<AbstractJobEvent> onJobInitiated(final JobInitiated jobInitiated) {
+		return underlyingResource.onJobInitiated(jobInitiated);
+	}
+
+	@Override
+	public Set<AbstractJobEvent> onJobProgressed(final JobProgressed jobProgressed) {
+		final double ranNumber = Math.random();
+		final Job job = jobProgressed.getEntity();
+
+		if (ranNumber < this.failureRate) {
+			underlyingResource.abortJob(job);
+
+			return Set.of(new JobAborted(job, 0, String.format(
+					"Linking resource simulated a failure: Number was %f and thus within the failure rate of %f",
+					ranNumber, this.failureRate)));
+		}
+
+		job.updateDemand(job.getDemand() + latency.calculateRV());
+		return underlyingResource.onJobProgressed(jobProgressed);
+	}
+
+}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/entities/GeneralEntryRequest.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/entities/GeneralEntryRequest.java
@@ -93,7 +93,14 @@ public final class GeneralEntryRequest extends UserContextEntityHolder {
 		return this.requestFrom;
 	}
 
-
+	public Builder update() {
+		return builder()
+				.withInputVariableUsages(inputVariableUsages)
+				.withRequestFrom(requestFrom)
+				.withRequiredRole(requiredRole)
+				.withSignature(signature)
+				.withUser(getUser());
+	}
 
 	/**
 	 * Creates builder to build {@link GeneralEntryRequest}.

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/entities/GeneralEntryRequest.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/entities/GeneralEntryRequest.java
@@ -29,6 +29,9 @@ public final class GeneralEntryRequest extends UserContextEntityHolder {
 	/** The input variables for the service call. */
 	private final EList<VariableUsage> inputVariableUsages;
 	
+	/** The output variables to calculate the return */
+	private final EList<VariableUsage> outputVariableUsages;
+
 	/** The interpreter from which the request originates. */
 	private final SEFFInterpretationContext requestFrom;
 
@@ -39,6 +42,7 @@ public final class GeneralEntryRequest extends UserContextEntityHolder {
 		this.signature = builder.signature;
 		this.inputVariableUsages = builder.inputVariableUsages;
 		this.requestFrom = builder.requestFrom;
+		this.outputVariableUsages = builder.outputVariableUsages;
 	}
 
 	/**
@@ -51,12 +55,14 @@ public final class GeneralEntryRequest extends UserContextEntityHolder {
 	 * @param inputVariableUsages The input variables for the call.
 	 */
 	public GeneralEntryRequest(final User user, final RequiredRole requiredRole, final Signature signature,
-	        final EList<VariableUsage> inputVariableUsages, final SEFFInterpretationContext requestFrom) {
+			final EList<VariableUsage> inputVariableUsages, final SEFFInterpretationContext requestFrom,
+			final EList<VariableUsage> outputVariableUsages) {
 		super(user);
 		this.requiredRole = requiredRole;
 		this.signature = signature;
 		this.inputVariableUsages = inputVariableUsages;
 		this.requestFrom = requestFrom;
+		this.outputVariableUsages = outputVariableUsages;
 	}
 	
 	
@@ -93,6 +99,10 @@ public final class GeneralEntryRequest extends UserContextEntityHolder {
 		return this.requestFrom;
 	}
 
+	public EList<VariableUsage> getOutputVariableUsages() {
+		return this.outputVariableUsages;
+	}
+
 	public Builder update() {
 		return builder()
 				.withInputVariableUsages(inputVariableUsages)
@@ -121,6 +131,7 @@ public final class GeneralEntryRequest extends UserContextEntityHolder {
 		private Signature signature;
 		private EList<VariableUsage> inputVariableUsages;
 		private SEFFInterpretationContext requestFrom;
+		private EList<VariableUsage> outputVariableUsages;
 
 		private Builder() {
 		}
@@ -142,6 +153,11 @@ public final class GeneralEntryRequest extends UserContextEntityHolder {
 
 		public Builder withInputVariableUsages(final EList<VariableUsage> inputVariableUsages) {
 			this.inputVariableUsages = inputVariableUsages;
+			return this;
+		}
+
+		public Builder withOutputVariableUsages(final EList<VariableUsage> outputVariableUsages) {
+			this.outputVariableUsages = outputVariableUsages;
 			return this;
 		}
 

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/entities/resource/CallOverWireRequest.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/entities/resource/CallOverWireRequest.java
@@ -1,5 +1,6 @@
 package org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.resource;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.GeneralEntryRequest;
@@ -7,14 +8,36 @@ import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.entities.Use
 import org.palladiosimulator.pcm.core.composition.AssemblyContext;
 import org.palladiosimulator.pcm.repository.Signature;
 
+/**
+ * This request is used for calls over the wire and contains all the information
+ * needed to make a call to the destination.
+ * 
+ * This can also be a reply to another request if {@link #getReplyTo()} is not
+ * empty.
+ * 
+ * @author Julijan Katic
+ */
 public final class CallOverWireRequest {
 
 	private final String id;
+
+	/** The information of where the call is coming from. */
 	private final AssemblyContext from;
+
+	/** Tells where the target component is with the target interface */
 	private final AssemblyContext to;
+
+	/** The signature at the target interface */
 	private final Signature signature;
+
+	/** The user who made the request */
 	private final User user;
+
+	/** The request to enter another SEFF component */
 	private final GeneralEntryRequest entryRequest;
+
+	/** The origin request this is responding to */
+	private final Optional<CallOverWireRequest> replyTo;
 
 	public CallOverWireRequest(final Builder builder) {
 		this.from = builder.from;
@@ -23,6 +46,7 @@ public final class CallOverWireRequest {
 		this.user = builder.user;
 		this.id = UUID.randomUUID().toString();
 		this.entryRequest = builder.entryRequest;
+		this.replyTo = Optional.ofNullable(builder.replyTo);
 	}
 
 	public String getId() {
@@ -49,6 +73,27 @@ public final class CallOverWireRequest {
 		return entryRequest;
 	}
 
+	public Optional<CallOverWireRequest> getReplyTo() {
+		return this.replyTo;
+	}
+	
+	/**
+	 * This creates a new response request such that the returned instance's
+	 * {@link #getReplyTo()} is not empty.
+	 * 
+	 * @return A response request to this one.
+	 */
+	public CallOverWireRequest createReplyRequest() {
+		return builder()
+				.from(this.from)
+				.to(this.to)
+				.entryRequest(this.entryRequest)
+				.signature(this.signature)
+				.user(this.user)
+				.replyTo(this)
+				.build();
+	}
+
 	public static Builder builder() {
 		return new Builder();
 	}
@@ -59,6 +104,7 @@ public final class CallOverWireRequest {
 		private Signature signature;
 		private User user;
 		private GeneralEntryRequest entryRequest;
+		private CallOverWireRequest replyTo;
 
 		private Builder() {
 		}
@@ -85,6 +131,11 @@ public final class CallOverWireRequest {
 
 		public Builder entryRequest(final GeneralEntryRequest entryRequest) {
 			this.entryRequest = entryRequest;
+			return this;
+		}
+
+		public Builder replyTo(final CallOverWireRequest replyTo) {
+			this.replyTo = replyTo;
 			return this;
 		}
 

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/entities/resource/CallOverWireRequest.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/entities/resource/CallOverWireRequest.java
@@ -1,0 +1,95 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.resource;
+
+import java.util.UUID;
+
+import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.GeneralEntryRequest;
+import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.entities.User;
+import org.palladiosimulator.pcm.core.composition.AssemblyContext;
+import org.palladiosimulator.pcm.repository.Signature;
+
+public final class CallOverWireRequest {
+
+	private final String id;
+	private final AssemblyContext from;
+	private final AssemblyContext to;
+	private final Signature signature;
+	private final User user;
+	private final GeneralEntryRequest entryRequest;
+
+	public CallOverWireRequest(final Builder builder) {
+		this.from = builder.from;
+		this.to = builder.to;
+		this.signature = builder.signature;
+		this.user = builder.user;
+		this.id = UUID.randomUUID().toString();
+		this.entryRequest = builder.entryRequest;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public AssemblyContext getFrom() {
+		return from;
+	}
+
+	public AssemblyContext getTo() {
+		return to;
+	}
+
+	public Signature getSignature() {
+		return signature;
+	}
+
+	public User getUser() {
+		return user;
+	}
+
+	public GeneralEntryRequest getEntryRequest() {
+		return entryRequest;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static final class Builder {
+		private AssemblyContext from;
+		private AssemblyContext to;
+		private Signature signature;
+		private User user;
+		private GeneralEntryRequest entryRequest;
+
+		private Builder() {
+		}
+
+		public Builder from(final AssemblyContext from) {
+			this.from = from;
+			return this;
+		}
+
+		public Builder to(final AssemblyContext to) {
+			this.to = to;
+			return this;
+		}
+
+		public Builder signature(final Signature signature) {
+			this.signature = signature;
+			return this;
+		}
+
+		public Builder user(final User user) {
+			this.user = user;
+			return this;
+		}
+
+		public Builder entryRequest(final GeneralEntryRequest entryRequest) {
+			this.entryRequest = entryRequest;
+			return this;
+		}
+
+		public CallOverWireRequest build() {
+			return new CallOverWireRequest(this);
+		}
+	}
+}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/entities/resource/CallOverWireRequest.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/entities/resource/CallOverWireRequest.java
@@ -8,6 +8,8 @@ import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.entities.Use
 import org.palladiosimulator.pcm.core.composition.AssemblyContext;
 import org.palladiosimulator.pcm.repository.Signature;
 
+import de.uka.ipd.sdq.simucomframework.variables.stackframe.SimulatedStackframe;
+
 /**
  * This request is used for calls over the wire and contains all the information
  * needed to make a call to the destination.
@@ -36,6 +38,9 @@ public final class CallOverWireRequest {
 	/** The request to enter another SEFF component */
 	private final GeneralEntryRequest entryRequest;
 
+	/** List of variables to consider for calculating the bytesize */
+	private final SimulatedStackframe<Object> variablesToConsider;
+
 	/** The origin request this is responding to */
 	private final Optional<CallOverWireRequest> replyTo;
 
@@ -47,10 +52,15 @@ public final class CallOverWireRequest {
 		this.id = UUID.randomUUID().toString();
 		this.entryRequest = builder.entryRequest;
 		this.replyTo = Optional.ofNullable(builder.replyTo);
+		this.variablesToConsider = builder.variablesToConsider;
 	}
 
 	public String getId() {
 		return id;
+	}
+
+	public SimulatedStackframe<Object> getVariablesToConsider() {
+		return this.variablesToConsider;
 	}
 
 	public AssemblyContext getFrom() {
@@ -79,11 +89,14 @@ public final class CallOverWireRequest {
 	
 	/**
 	 * This creates a new response request such that the returned instance's
-	 * {@link #getReplyTo()} is not empty.
+	 * {@link #getReplyTo()} is not empty, and switches the stackframe to consider
+	 * for the bytesize calculation.
 	 * 
+	 * @param returnStackframe The stackframe to consider for the new bytesize
+	 *                         calculation.
 	 * @return A response request to this one.
 	 */
-	public CallOverWireRequest createReplyRequest() {
+	public CallOverWireRequest createReplyRequest(final SimulatedStackframe<Object> returnStackframe) {
 		return builder()
 				.from(this.from)
 				.to(this.to)
@@ -91,6 +104,7 @@ public final class CallOverWireRequest {
 				.signature(this.signature)
 				.user(this.user)
 				.replyTo(this)
+				.variablesToConsider(returnStackframe)
 				.build();
 	}
 
@@ -105,6 +119,7 @@ public final class CallOverWireRequest {
 		private User user;
 		private GeneralEntryRequest entryRequest;
 		private CallOverWireRequest replyTo;
+		private SimulatedStackframe<Object> variablesToConsider;
 
 		private Builder() {
 		}
@@ -136,6 +151,11 @@ public final class CallOverWireRequest {
 
 		public Builder replyTo(final CallOverWireRequest replyTo) {
 			this.replyTo = replyTo;
+			return this;
+		}
+
+		public Builder variablesToConsider(final SimulatedStackframe<Object> variablesToConsider) {
+			this.variablesToConsider = variablesToConsider;
 			return this;
 		}
 

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/entities/seff/SEFFInterpretationContext.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/entities/seff/SEFFInterpretationContext.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import javax.annotation.processing.Generated;
 
+import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.resource.CallOverWireRequest;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.seff.behaviorcontext.SeffBehaviorContextHolder;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.user.RequestProcessingContext;
 import org.palladiosimulator.pcm.core.composition.AssemblyContext;
@@ -32,12 +33,15 @@ public final class SEFFInterpretationContext {
 
 	private final Optional<SEFFInterpretationContext> calledFrom;
 
+	private final Optional<CallOverWireRequest> callOverWireRequest;
+
 	@Generated("SparkTools")
 	private SEFFInterpretationContext(final Builder builder) {
 		this.calledFrom = builder.calledFrom;
 		this.behaviorContext = builder.behaviorContext;
 		this.requestProcessingContext = builder.requestProcessingContext;
 		this.assemblyContext = builder.assemblyContext;
+		this.callOverWireRequest = Optional.ofNullable(builder.callOverWireRequest);
 	}
 
 	/**
@@ -62,11 +66,17 @@ public final class SEFFInterpretationContext {
 		return this.calledFrom;
 	}
 
+	public Optional<CallOverWireRequest> getCallOverWireRequest() {
+		return this.callOverWireRequest;
+	}
+
 	public Builder update() {
 		return builder()
 				.withBehaviorContext(this.behaviorContext)
 				.withAssemblyContext(this.assemblyContext)
-				.withRequestProcessingContext(this.requestProcessingContext);
+				.withRequestProcessingContext(this.requestProcessingContext)
+				.withCaller(calledFrom)
+				.withCallOverWireRequest(this.callOverWireRequest.orElse(null));
 	}
 
 	/**
@@ -88,8 +98,14 @@ public final class SEFFInterpretationContext {
 		private RequestProcessingContext requestProcessingContext;
 		private AssemblyContext assemblyContext;
 		private Optional<SEFFInterpretationContext> calledFrom = Optional.empty();
+		private CallOverWireRequest callOverWireRequest;
 
 		private Builder() {
+		}
+
+		public Builder withCallOverWireRequest(final CallOverWireRequest callOverWireRequest) {
+			this.callOverWireRequest = callOverWireRequest;
+			return this;
 		}
 
 		public Builder withBehaviorContext(final SeffBehaviorContextHolder behaviorContext) {

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/events/AbstractCallOverWireEvent.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/events/AbstractCallOverWireEvent.java
@@ -1,0 +1,18 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events;
+
+import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.resource.CallOverWireRequest;
+import org.palladiosimulator.analyzer.slingshot.common.events.AbstractSimulationEvent;
+
+public abstract class AbstractCallOverWireEvent extends AbstractSimulationEvent {
+
+	private final CallOverWireRequest callOverWireRequest;
+
+	public AbstractCallOverWireEvent(final CallOverWireRequest callOverWireRequest) {
+		this.callOverWireRequest = callOverWireRequest;
+	}
+
+	public CallOverWireRequest getRequest() {
+		return this.callOverWireRequest;
+	}
+
+}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/events/CallOverWireAborted.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/events/CallOverWireAborted.java
@@ -1,0 +1,13 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events;
+
+import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.resource.CallOverWireRequest;
+
+public final class CallOverWireAborted extends AbstractCallOverWireEvent {
+
+	public CallOverWireAborted(final CallOverWireRequest callOverWireRequest) {
+		super(callOverWireRequest);
+		// TODO Auto-generated constructor stub
+	}
+
+
+}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/events/CallOverWireRequested.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/events/CallOverWireRequested.java
@@ -10,9 +10,9 @@ import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entiti
  * 
  * @author Julijan Katic
  */
-public final class ExternalCallRequested extends AbstractCallOverWireEvent {
+public final class CallOverWireRequested extends AbstractCallOverWireEvent {
 
-	public ExternalCallRequested(final CallOverWireRequest callOverWireRequest) {
+	public CallOverWireRequested(final CallOverWireRequest callOverWireRequest) {
 		super(callOverWireRequest);
 	}
 

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/events/CallOverWireSucceeded.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/events/CallOverWireSucceeded.java
@@ -1,0 +1,12 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events;
+
+import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.resource.CallOverWireRequest;
+
+public final class CallOverWireSucceeded extends AbstractCallOverWireEvent {
+
+	public CallOverWireSucceeded(final CallOverWireRequest callOverWireRequest) {
+		super(callOverWireRequest);
+		// TODO Auto-generated constructor stub
+	}
+
+}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/events/ExternalCallRequested.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/events/ExternalCallRequested.java
@@ -1,0 +1,42 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events;
+
+import org.palladiosimulator.analyzer.slingshot.common.events.AbstractSimulationEvent;
+import org.palladiosimulator.pcm.core.composition.AssemblyContext;
+import org.palladiosimulator.pcm.repository.Signature;
+
+/**
+ * This event is used to indicate that a call from a SEFF to somewhere outside
+ * is being made (i.e., the call to another component of the system). This is
+ * important insofar that the other component *might* be on another resource
+ * container, and thus the latency of the network must be incorporated.
+ * 
+ * @author Julijan Katic
+ */
+public final class ExternalCallRequested extends AbstractSimulationEvent {
+
+	private final AssemblyContext from;
+	private final AssemblyContext to;
+	private final Signature signature;
+
+	public ExternalCallRequested(final AssemblyContext from, final AssemblyContext to,
+			final Signature signature) {
+		super();
+		this.from = from;
+		this.to = to;
+		this.signature = signature;
+	}
+
+	public AssemblyContext getFrom() {
+		return from;
+	}
+
+	public AssemblyContext getTo() {
+		return to;
+	}
+
+	public Signature getSignature() {
+		return signature;
+	}
+
+
+}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/events/ExternalCallRequested.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/events/ExternalCallRequested.java
@@ -1,5 +1,6 @@
 package org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events;
 
+import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.entities.User;
 import org.palladiosimulator.analyzer.slingshot.common.events.AbstractSimulationEvent;
 import org.palladiosimulator.pcm.core.composition.AssemblyContext;
 import org.palladiosimulator.pcm.repository.Signature;
@@ -17,13 +18,15 @@ public final class ExternalCallRequested extends AbstractSimulationEvent {
 	private final AssemblyContext from;
 	private final AssemblyContext to;
 	private final Signature signature;
+	private final User user;
 
 	public ExternalCallRequested(final AssemblyContext from, final AssemblyContext to,
-			final Signature signature) {
+			final Signature signature, final User user) {
 		super();
 		this.from = from;
 		this.to = to;
 		this.signature = signature;
+		this.user = user;
 	}
 
 	public AssemblyContext getFrom() {
@@ -38,5 +41,7 @@ public final class ExternalCallRequested extends AbstractSimulationEvent {
 		return signature;
 	}
 
-
+	public User getUser() {
+		return user;
+	}
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/events/ExternalCallRequested.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/events/ExternalCallRequested.java
@@ -1,9 +1,6 @@
 package org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events;
 
-import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.entities.User;
-import org.palladiosimulator.analyzer.slingshot.common.events.AbstractSimulationEvent;
-import org.palladiosimulator.pcm.core.composition.AssemblyContext;
-import org.palladiosimulator.pcm.repository.Signature;
+import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.resource.CallOverWireRequest;
 
 /**
  * This event is used to indicate that a call from a SEFF to somewhere outside
@@ -13,35 +10,11 @@ import org.palladiosimulator.pcm.repository.Signature;
  * 
  * @author Julijan Katic
  */
-public final class ExternalCallRequested extends AbstractSimulationEvent {
+public final class ExternalCallRequested extends AbstractCallOverWireEvent {
 
-	private final AssemblyContext from;
-	private final AssemblyContext to;
-	private final Signature signature;
-	private final User user;
-
-	public ExternalCallRequested(final AssemblyContext from, final AssemblyContext to,
-			final Signature signature, final User user) {
-		super();
-		this.from = from;
-		this.to = to;
-		this.signature = signature;
-		this.user = user;
+	public ExternalCallRequested(final CallOverWireRequest callOverWireRequest) {
+		super(callOverWireRequest);
 	}
 
-	public AssemblyContext getFrom() {
-		return from;
-	}
 
-	public AssemblyContext getTo() {
-		return to;
-	}
-
-	public Signature getSignature() {
-		return signature;
-	}
-
-	public User getUser() {
-		return user;
-	}
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SeffSimulationBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SeffSimulationBehavior.java
@@ -7,7 +7,7 @@ import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entiti
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.seff.behaviorcontext.ForkBehaviorContextHolder;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.seff.behaviorcontext.InfrastructureCallsContextHolder;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.seff.behaviorcontext.SeffBehaviorContextHolder;
-import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.ExternalCallRequested;
+import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.CallOverWireRequested;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.PassiveResourceAcquired;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.SEFFChildInterpretationStarted;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.SEFFInterpretationFinished;
@@ -148,7 +148,7 @@ public class SeffSimulationBehavior implements SimulationBehaviorExtension {
 	private AbstractSimulationEvent continueInCaller(final SEFFInterpretationContext entity) {
 		return entity.getCallOverWireRequest()
 				.map(cowReq -> cowReq.createReplyRequest(entity.getCurrentResultStackframe()))
-				.map(ExternalCallRequested::new)
+				.map(CallOverWireRequested::new)
 				.map(AbstractSimulationEvent.class::cast) // Needed for the type check
 				.orElseGet(() -> {
 					LOGGER.info("It seems that the call was not over a wire, so proceed with normal progression");

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SystemSimulationBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SystemSimulationBehavior.java
@@ -19,8 +19,8 @@ import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entiti
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.user.RequestProcessingContext;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.ActiveResourceFinished;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.CallOverWireAborted;
-import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.CallOverWireSucceeded;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.CallOverWireRequested;
+import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.CallOverWireSucceeded;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.RepositoryInterpretationInitiated;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.SEFFExternalActionCalled;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.SEFFInfrastructureCalled;
@@ -199,7 +199,7 @@ public class SystemSimulationBehavior implements SimulationBehaviorExtension {
 					.variablesToConsider(inputStackframe)
 					.build();
 			
-			
+			// TODO: Should we do the check whether resource containers are connected here?
 
 			return Result.of(new CallOverWireRequested(request));
 		}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SystemSimulationBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SystemSimulationBehavior.java
@@ -20,7 +20,7 @@ import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entiti
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.ActiveResourceFinished;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.CallOverWireAborted;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.CallOverWireSucceeded;
-import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.ExternalCallRequested;
+import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.CallOverWireRequested;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.RepositoryInterpretationInitiated;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.SEFFExternalActionCalled;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.SEFFInfrastructureCalled;
@@ -59,9 +59,9 @@ import de.uka.ipd.sdq.simucomframework.variables.stackframe.SimulatedStackframe;
  */
 @OnEvent(when = UserEntryRequested.class, then = SEFFInterpretationProgressed.class, cardinality = SINGLE)
 @OnEvent(when = RepositoryInterpretationInitiated.class, then = SEFFInterpretationProgressed.class, cardinality = MANY)
-@OnEvent(when = SEFFExternalActionCalled.class, then = ExternalCallRequested.class, cardinality = MANY)
+@OnEvent(when = SEFFExternalActionCalled.class, then = CallOverWireRequested.class, cardinality = MANY)
 @OnEvent(when = CallOverWireSucceeded.class, then = SEFFInterpretationProgressed.class, cardinality = MANY)
-@OnEvent(when = CallOverWireAborted.class, then = ExternalCallRequested.class, cardinality = MANY)
+@OnEvent(when = CallOverWireAborted.class, then = CallOverWireRequested.class, cardinality = MANY)
 @OnEvent(when = ActiveResourceFinished.class, then = SEFFInterpretationProgressed.class, cardinality = MANY)
 @OnEvent(when = SEFFInfrastructureCalled.class, then = SEFFInterpretationProgressed.class, cardinality = SINGLE)
 public class SystemSimulationBehavior implements SimulationBehaviorExtension {
@@ -201,7 +201,7 @@ public class SystemSimulationBehavior implements SimulationBehaviorExtension {
 			
 			
 
-			return Result.of(new ExternalCallRequested(request));
+			return Result.of(new CallOverWireRequested(request));
 		}
 		return Result.of();
 	}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SystemSimulationBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SystemSimulationBehavior.java
@@ -178,8 +178,10 @@ public class SystemSimulationBehavior implements SimulationBehaviorExtension {
 			final Set<DESEvent> appearedEvents = new HashSet<>(interpreter
 					.doSwitch(assemblyContext.get().getEncapsulatedComponent__AssemblyContext()));
 			
+			SimulatedStackHelper.createAndPushNewStackFrame(entity.getUser().getStack(),
+					entity.getInputVariableUsages());
 			appearedEvents.add(new ExternalCallRequested(entity.getRequestFrom().getAssemblyContext(),
-					assemblyContext.get(), entity.getSignature()));
+					assemblyContext.get(), entity.getSignature(), entity.getUser()));
 
 			return Result.of(appearedEvents);
 		}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/interpreters/RepositoryInterpreter.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/interpreters/RepositoryInterpreter.java
@@ -9,6 +9,7 @@ import org.apache.log4j.Logger;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
+import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.resource.CallOverWireRequest;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.seff.SEFFInterpretationContext;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.seff.behaviorcontext.RootBehaviorContextHolder;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.user.RequestProcessingContext;
@@ -67,6 +68,8 @@ public class RepositoryInterpreter extends RepositorySwitch<Set<SEFFInterpretati
 	/** The context of the calling seff */
 	private final Optional<SEFFInterpretationContext> callerContext;
 
+	private final CallOverWireRequest callOverWireRequest;
+
 	/**
 	 * Instantiates the interpreter with given information. Depending on the
 	 * interpretation, not every parameter must be set (every parameter CAN be
@@ -83,13 +86,14 @@ public class RepositoryInterpreter extends RepositorySwitch<Set<SEFFInterpretati
 	 */
 	public RepositoryInterpreter(final AssemblyContext context, final Signature signature,
 			final ProvidedRole providedRole, final User user, final SystemModelRepository modelRepository,
-			final Optional<SEFFInterpretationContext> callerContext) {
+			final Optional<SEFFInterpretationContext> callerContext, final CallOverWireRequest request) {
 		this.assemblyContext = context;
 		this.signature = signature;
 		this.providedRole = providedRole;
 		this.user = user;
 		this.modelRepository = modelRepository;
 		this.callerContext = callerContext;
+		this.callOverWireRequest = request;
 	}
 
 	/**
@@ -123,6 +127,7 @@ public class RepositoryInterpreter extends RepositorySwitch<Set<SEFFInterpretati
 							.withRequestProcessingContext(
 									RequestProcessingContext.builder().withAssemblyContext(this.assemblyContext)
 											.withProvidedRole(this.providedRole).withUser(this.user).build())
+							.withCallOverWireRequest(callOverWireRequest)
 							.build();
 					return new SEFFInterpretationProgressed(context);
 				}).collect(Collectors.toSet());
@@ -200,7 +205,7 @@ public class RepositoryInterpreter extends RepositorySwitch<Set<SEFFInterpretati
 		final RepositoryInterpreter repositoryInterpreter = new RepositoryInterpreter(
 				connectedProvidedDelegationConnector.getAssemblyContext_ProvidedDelegationConnector(), this.signature,
 				connectedProvidedDelegationConnector.getInnerProvidedRole_ProvidedDelegationConnector(), this.user,
-				this.modelRepository, Optional.empty());
+				this.modelRepository, Optional.empty(), this.callOverWireRequest);
 		return repositoryInterpreter
 				.doSwitch(connectedProvidedDelegationConnector.getInnerProvidedRole_ProvidedDelegationConnector());
 	}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/interpreters/RepositoryInterpreter.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/interpreters/RepositoryInterpreter.java
@@ -68,25 +68,38 @@ public class RepositoryInterpreter extends RepositorySwitch<Set<SEFFInterpretati
 	/** The context of the calling seff */
 	private final Optional<SEFFInterpretationContext> callerContext;
 
+	/** Needed for creating the appropriate SEFF Interpretation Context */
 	private final CallOverWireRequest callOverWireRequest;
+
+	/**
+	 * The stackframe to set variables into. Needed for creating the appropriate
+	 * SEFF Interpretation Context
+	 */
+	private final SimulatedStackframe<Object> resultStackframe;
 
 	/**
 	 * Instantiates the interpreter with given information. Depending on the
 	 * interpretation, not every parameter must be set (every parameter CAN be
 	 * null!).
 	 *
-	 * @param context         The special assembly context to interpret.
-	 * @param signature       A signature to find the right RDSeff.
-	 * @param providedRole    The provided role from which the interpretation
-	 *                        started.
-	 * @param user            The context onto which to push stack frames for
-	 *                        RDSeffs.
-	 * @param modelRepository The model repository to get more information from the
-	 *                        system model.
+	 * @param context          The special assembly context to interpret.
+	 * @param signature        A signature to find the right RDSeff.
+	 * @param providedRole     The provided role from which the interpretation
+	 *                         started.
+	 * @param user             The context onto which to push stack frames for
+	 *                         RDSeffs.
+	 * @param modelRepository  The model repository to get more information from the
+	 *                         system model.
+	 * @param callerContext    The context of the caller.
+	 * @param request          The call over wire request needed for the next SEFF
+	 *                         interpretation.
+	 * @param resultStackframe The stackframe to put output variables into. Needed
+	 *                         for the next SEFF interpretation.
 	 */
 	public RepositoryInterpreter(final AssemblyContext context, final Signature signature,
 			final ProvidedRole providedRole, final User user, final SystemModelRepository modelRepository,
-			final Optional<SEFFInterpretationContext> callerContext, final CallOverWireRequest request) {
+			final Optional<SEFFInterpretationContext> callerContext, final CallOverWireRequest request,
+			final SimulatedStackframe<Object> resultStackframe) {
 		this.assemblyContext = context;
 		this.signature = signature;
 		this.providedRole = providedRole;
@@ -94,6 +107,7 @@ public class RepositoryInterpreter extends RepositorySwitch<Set<SEFFInterpretati
 		this.modelRepository = modelRepository;
 		this.callerContext = callerContext;
 		this.callOverWireRequest = request;
+		this.resultStackframe = resultStackframe;
 	}
 
 	/**
@@ -128,6 +142,7 @@ public class RepositoryInterpreter extends RepositorySwitch<Set<SEFFInterpretati
 									RequestProcessingContext.builder().withAssemblyContext(this.assemblyContext)
 											.withProvidedRole(this.providedRole).withUser(this.user).build())
 							.withCallOverWireRequest(callOverWireRequest)
+							.withResultStackframe(this.resultStackframe)
 							.build();
 					return new SEFFInterpretationProgressed(context);
 				}).collect(Collectors.toSet());
@@ -205,7 +220,7 @@ public class RepositoryInterpreter extends RepositorySwitch<Set<SEFFInterpretati
 		final RepositoryInterpreter repositoryInterpreter = new RepositoryInterpreter(
 				connectedProvidedDelegationConnector.getAssemblyContext_ProvidedDelegationConnector(), this.signature,
 				connectedProvidedDelegationConnector.getInnerProvidedRole_ProvidedDelegationConnector(), this.user,
-				this.modelRepository, Optional.empty(), this.callOverWireRequest);
+				this.modelRepository, Optional.empty(), this.callOverWireRequest, this.resultStackframe);
 		return repositoryInterpreter
 				.doSwitch(connectedProvidedDelegationConnector.getInnerProvidedRole_ProvidedDelegationConnector());
 	}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/interpreters/SeffInterpreter.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/interpreters/SeffInterpreter.java
@@ -123,9 +123,12 @@ public class SeffInterpreter extends SeffSwitch<Set<SEFFInterpreted>> {
 		final BranchBehaviorContextHolder holder = new BranchBehaviorContextHolder(
 				branchTransition.getBranchBehaviour_BranchTransition(), branchAction.getSuccessor_AbstractAction(),
 				this.context.getBehaviorContext().getCurrentProcessedBehavior());
-		final SEFFInterpretationContext childContext = SEFFInterpretationContext.builder().withBehaviorContext(holder)
+		final SEFFInterpretationContext childContext = this.context.createChildContext()
+				.withBehaviorContext(holder)
 				.withRequestProcessingContext(this.context.getRequestProcessingContext())
-				.withCaller(this.context.getCaller()).withAssemblyContext(this.context.getAssemblyContext()).build();
+				.withCaller(this.context.getCaller())
+				.withAssemblyContext(this.context.getAssemblyContext())
+				.build();
 
 		final SEFFChildInterpretationStarted event = new SEFFChildInterpretationStarted(childContext);
 

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/interpreters/SeffInterpreter.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/interpreters/SeffInterpreter.java
@@ -346,7 +346,7 @@ public class SeffInterpreter extends SeffSwitch<Set<SEFFInterpreted>> {
 				final InfrastructureCallsContextHolder infraContext = new InfrastructureCallsContextHolder(this.context,
 						internalAction, this.context.getBehaviorContext().getCurrentProcessedBehavior());
 
-				final SEFFInterpretationContext infraChildContext = SEFFInterpretationContext.builder()
+				final SEFFInterpretationContext infraChildContext = this.context.createChildContext()
 						.withBehaviorContext(infraContext)
 						.withRequestProcessingContext(this.context.getRequestProcessingContext())
 						.withCaller(this.context.getCaller()).withAssemblyContext(this.context.getAssemblyContext())

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/interpreters/SeffInterpreter.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/interpreters/SeffInterpreter.java
@@ -189,7 +189,7 @@ public class SeffInterpreter extends SeffSwitch<Set<SEFFInterpreted>> {
 						.build())
 				.collect(Collectors.toList());
 
-		return childContexts.stream().map(childContext -> new SEFFChildInterpretationStarted(childContext))
+		return childContexts.stream().map(SEFFChildInterpretationStarted::new)
 				.collect(Collectors.toSet());
 	}
 
@@ -211,6 +211,7 @@ public class SeffInterpreter extends SeffSwitch<Set<SEFFInterpreted>> {
 				.withInputVariableUsages(inputVariableUsages).withRequiredRole(requiredRole)
 				.withSignature(calledServiceSignature).withUser(this.context.getRequestProcessingContext().getUser())
 				.withRequestFrom(this.context.update().withCaller(this.context).build()).build();
+
 
 		return Set.of(new SEFFExternalActionCalled(entryRequest));
 	}
@@ -300,10 +301,9 @@ public class SeffInterpreter extends SeffSwitch<Set<SEFFInterpreted>> {
 					.withRequestFrom(this.context.update().withCaller(this.context).build()).build();
 
 			return Set.of(new SEFFInfrastructureCalled(request));
-		} else {
-			LOGGER.warn("Attention, no interpreation implemented for this specific CallAction, it is simply ignored!");
-			return Set.of();
 		}
+		LOGGER.warn("Attention, no interpreation implemented for this specific CallAction, it is simply ignored!");
+		return Set.of();
 	}
 
 	/**


### PR DESCRIPTION
This PR introduces a behavior of simulating linking resources in Palladio Slingshot. Unfortunately, this comes with some quite changes. If approved, this PR will close #18 .

# Before
While external calls were able to find the right container and make a successful call, it was ignored whether the components are allocated on different resource containers. (I.e., it was handled as if everything was in one big resource container, or as if the world was perfect and requests over the internet happen instantly without latency)

# Now
Slingshot will introduce latency to calls over the wire with the respective latency specification in the model. The throughput decides how much data can be put into the wire at once.

# Implementation
The important class here is `SimulatedLinkingResource`, which extends the `FCFSResource`. This means that a linking resource acts like an FCFS resource. However, the throughput is the rate of the resource. Furthermore, the linking resource can abort a job accordingly to the failure rate.

This introduces some changes:

1. Before, a `Job` was considered to be something on the resource container. However, jobs can now also perform on linking resources. Thus, `Job` was split into two subclasses `ActiveJob` and `LinkingJob`, both convey and hold different information needed for the simulator.
2. The active resources still receive any `Job` (not only `ActiveJob`), since those resource could potentionally act as different resources of different types.
3. New events were introduced:
 * `ExternalCallRequested`: Create a job for the linking resource if the external call happens to be over the wire.
 * `CallOverWireSucceeded`: If the job successfully finishes, then this information conveys to the systems simulator that it can proceed with the interpretation of the seff.
 * `CallOverWireAborted`: If the job was aborted, then this signals to the system simulator to retry.
 * `JobAborted`: Generally says that a job has been aborted due to some failure, be it a simulated failure (i.e. `failureRate` in the linking resource) OR due to an exception.
4. Furthermore, a new kind of resource table was introduced solely for the linking resources.

# Tests
The minimal linking resource example from Palladio succeeds with the correct latency (or here, resource demand on the linking resource). The simulation advances accordingly.