### PR TITLE
refactor number of elements monitor to use spd MPs.

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/META-INF/MANIFEST.MF
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/META-INF/MANIFEST.MF
@@ -16,4 +16,5 @@ Require-Bundle: org.palladiosimulator.analyzer.slingshot.core;bundle-version="1.
  org.palladiosimulator.analyzer.slingshot.monitor;bundle-version="1.0.0",
  org.palladiosimulator.analyzer.slingshot.monitor.utils,
  org.palladiosimulator.analyzer.slingshot.behavior.spd.data;bundle-version="1.0.0",
- org.palladiosimulator.spd.semantic
+ org.palladiosimulator.spd.semantic,
+ org.palladiosimulator.spd.measuringpoint;bundle-version="1.0.0"

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/monitor/NumberOfElementsMonitorBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/monitor/NumberOfElementsMonitorBehavior.java
@@ -26,13 +26,12 @@ import org.palladiosimulator.edp2.util.MetricDescriptionUtility;
 import org.palladiosimulator.metricspec.constants.MetricDescriptionConstants;
 import org.palladiosimulator.monitorrepository.MeasurementSpecification;
 import org.palladiosimulator.pcm.resourceenvironment.ResourceContainer;
-import org.palladiosimulator.pcmmeasuringpoint.ResourceContainerMeasuringPoint;
-import org.palladiosimulator.pcmmeasuringpoint.ResourceEnvironmentMeasuringPoint;
 import org.palladiosimulator.probeframework.calculator.Calculator;
 import org.palladiosimulator.probeframework.calculator.DefaultCalculatorProbeSets;
 import org.palladiosimulator.probeframework.calculator.IGenericCalculatorFactory;
 import org.palladiosimulator.semanticspd.Configuration;
 import org.palladiosimulator.semanticspd.ElasticInfrastructureCfg;
+import org.palladiosimulator.spdmeasuringpoint.SPDResourceContainerMeasuringPoint;
 
 /**
  *
@@ -87,9 +86,9 @@ public class NumberOfElementsMonitorBehavior implements SimulationBehaviorExtens
 		final MeasurementSpecification spec = m.getEntity();
 		final MeasuringPoint measuringPoint = spec.getMonitor().getMeasuringPoint();
 
-		if (measuringPoint instanceof ResourceContainerMeasuringPoint) {
+		if (measuringPoint instanceof SPDResourceContainerMeasuringPoint) {
 			// Container MP --> register probe for EI where container is unit
-			final ResourceContainerMeasuringPoint resourceContainerMeasuringPoint = (ResourceContainerMeasuringPoint) measuringPoint;
+			final SPDResourceContainerMeasuringPoint resourceContainerMeasuringPoint = (SPDResourceContainerMeasuringPoint) measuringPoint;
 
 			if (MetricDescriptionUtility.metricDescriptionIdsEqual(spec.getMetricDescription(),
 					MetricDescriptionConstants.NUMBER_OF_RESOURCE_CONTAINERS)) {

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/monitor/NumberOfElementsMonitorBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/monitor/NumberOfElementsMonitorBehavior.java
@@ -38,18 +38,14 @@ import org.palladiosimulator.spdmeasuringpoint.SPDResourceContainerMeasuringPoin
  * Behavior to monitor the number of elements in a Elastic Infrastructure.
  *
  * The behavior creates Probes and Calculators for
- * {@link ResourceContainerMeasuringPoint}s. Beware it does *not* react to
- * {@link ResourceEnvironmentMeasuringPoint}s, as we cannot determine the target
- * group configuration from that measuring point.
+ * {@link SPDResourceContainerMeasuringPoint}s.
  *
- * For a {@link ResourceContainerMeasuringPoint}, the behavior creates a probe
- * and a calculator for the given resource container, iff the resource container
- * is {@code unit} in any of the given target configurations.
+ * For a {@link SPDResourceContainerMeasuringPoint}, the behavior creates a
+ * probe and a calculator for the given resource container, iff the resource
+ * container is {@code unit} in any of the given target configurations.
  *
  * The metric specification must be the base metric "number of resource
  * containers".
- *
- *
  *
  * @author Sarah Stieß
  *

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/monitor/NumberOfElementsMonitorBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/monitor/NumberOfElementsMonitorBehavior.java
@@ -49,12 +49,6 @@ import org.palladiosimulator.spdmeasuringpoint.SPDResourceContainerMeasuringPoin
  * The metric specification must be the base metric "number of resource
  * containers".
  *
- * Beware : this behaviour is only a temporary workaround. In the future there
- * should be a afor a target group. In that way the modeller knows that the
- * measuring point is bound to the concepts that SPD contributes. In the current
- * way the modeller is unaware that the combination MP on the Resource Container
- * and the metric Number of Resource Container is valid only when the SPD
- * extension is active in Slingshot.
  *
  *
  * @author Sarah Stieß

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/META-INF/MANIFEST.MF
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/META-INF/MANIFEST.MF
@@ -17,4 +17,7 @@ Require-Bundle: org.palladiosimulator.analyzer.slingshot.core,
  org.palladiosimulator.analyzer.slingshot.monitor;bundle-version="1.0.0",
  org.palladiosimulator.analyzer.slingshot.behavior.usagesimulation.data,
  org.palladiosimulator.pcm.edp2.measuringpoint;bundle-version="5.1.0",
- org.palladiosimulator.analyzer.slingshot.common.utils
+ org.palladiosimulator.analyzer.slingshot.common.utils,
+ org.palladiosimulator.spd.semantic,
+ org.palladiosimulator.spd.measuringpoint;bundle-version="1.0.0",
+ org.palladiosimulator.analyzer.slingshot.behavior.spd.data;bundle-version="1.0.0"


### PR DESCRIPTION
## Current Behaviour

Number of Elements for Resource Container are based on the general PCM Resource Container MP.

## New Behaviour

Number of Elements for Resource Container are based on the SPD specific Resource Container MP (c.f. PalladioSimulator/Palladio-Addons-SPD-Metamodel#19) and require the SPD specific MPs to be merged first. 

## Misc
Deprecated, see comments below.