### PR TITLE
Number of elements for sg and cc ghack

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/META-INF/MANIFEST.MF
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/META-INF/MANIFEST.MF
@@ -16,4 +16,5 @@ Require-Bundle: org.palladiosimulator.analyzer.slingshot.core;bundle-version="1.
  org.palladiosimulator.analyzer.slingshot.monitor;bundle-version="1.0.0",
  org.palladiosimulator.analyzer.slingshot.monitor.utils,
  org.palladiosimulator.analyzer.slingshot.behavior.spd.data;bundle-version="1.0.0",
- org.palladiosimulator.spd.semantic
+ org.palladiosimulator.spd.semantic,
+ org.palladiosimulator.spd.measuringpoint;bundle-version="1.0.0"

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/monitor/NumberOfElementsMonitorBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/monitor/NumberOfElementsMonitorBehavior.java
@@ -26,13 +26,12 @@ import org.palladiosimulator.edp2.util.MetricDescriptionUtility;
 import org.palladiosimulator.metricspec.constants.MetricDescriptionConstants;
 import org.palladiosimulator.monitorrepository.MeasurementSpecification;
 import org.palladiosimulator.pcm.resourceenvironment.ResourceContainer;
-import org.palladiosimulator.pcmmeasuringpoint.ResourceContainerMeasuringPoint;
-import org.palladiosimulator.pcmmeasuringpoint.ResourceEnvironmentMeasuringPoint;
 import org.palladiosimulator.probeframework.calculator.Calculator;
 import org.palladiosimulator.probeframework.calculator.DefaultCalculatorProbeSets;
 import org.palladiosimulator.probeframework.calculator.IGenericCalculatorFactory;
 import org.palladiosimulator.semanticspd.Configuration;
 import org.palladiosimulator.semanticspd.ElasticInfrastructureCfg;
+import org.palladiosimulator.spdmeasuringpoint.SPDResourceContainerMeasuringPoint;
 
 /**
  *
@@ -87,9 +86,9 @@ public class NumberOfElementsMonitorBehavior implements SimulationBehaviorExtens
 		final MeasurementSpecification spec = m.getEntity();
 		final MeasuringPoint measuringPoint = spec.getMonitor().getMeasuringPoint();
 
-		if (measuringPoint instanceof ResourceContainerMeasuringPoint) {
+		if (measuringPoint instanceof SPDResourceContainerMeasuringPoint) {
 			// Container MP --> register probe for EI where container is unit
-			final ResourceContainerMeasuringPoint resourceContainerMeasuringPoint = (ResourceContainerMeasuringPoint) measuringPoint;
+			final SPDResourceContainerMeasuringPoint resourceContainerMeasuringPoint = (SPDResourceContainerMeasuringPoint) measuringPoint;
 
 			if (MetricDescriptionUtility.metricDescriptionIdsEqual(spec.getMetricDescription(),
 					MetricDescriptionConstants.NUMBER_OF_RESOURCE_CONTAINERS)) {

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/monitor/NumberOfElementsMonitorBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/monitor/NumberOfElementsMonitorBehavior.java
@@ -3,7 +3,6 @@ package org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.mon
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -31,7 +30,7 @@ import org.palladiosimulator.probeframework.calculator.DefaultCalculatorProbeSet
 import org.palladiosimulator.probeframework.calculator.IGenericCalculatorFactory;
 import org.palladiosimulator.semanticspd.Configuration;
 import org.palladiosimulator.semanticspd.ElasticInfrastructureCfg;
-import org.palladiosimulator.spdmeasuringpoint.SPDResourceContainerMeasuringPoint;
+import org.palladiosimulator.spdmeasuringpoint.ElasticInfrastructureMeasuringPoint;
 
 /**
  *
@@ -76,24 +75,16 @@ public class NumberOfElementsMonitorBehavior implements SimulationBehaviorExtens
 		final MeasurementSpecification spec = m.getEntity();
 		final MeasuringPoint measuringPoint = spec.getMonitor().getMeasuringPoint();
 
-		if (measuringPoint instanceof SPDResourceContainerMeasuringPoint) {
+		if (measuringPoint instanceof ElasticInfrastructureMeasuringPoint) {
 			// Container MP --> register probe for EI where container is unit
-			final SPDResourceContainerMeasuringPoint resourceContainerMeasuringPoint = (SPDResourceContainerMeasuringPoint) measuringPoint;
+			final ElasticInfrastructureMeasuringPoint resourceContainerMeasuringPoint = (ElasticInfrastructureMeasuringPoint) measuringPoint;
 
 			if (MetricDescriptionUtility.metricDescriptionIdsEqual(spec.getMetricDescription(),
 					MetricDescriptionConstants.NUMBER_OF_RESOURCE_CONTAINERS)) {
 
-				final Optional<ElasticInfrastructureCfg> elasticInfrastructureCfg = this.semanticConfiguration
-						.getTargetCfgs().stream().filter(cfg -> (cfg instanceof ElasticInfrastructureCfg))
-						.map(eicfg -> ((ElasticInfrastructureCfg) eicfg)).filter(eicfg -> eicfg.getUnit().getId()
-								.equals(resourceContainerMeasuringPoint.getResourceContainer().getId()))
-						.findAny();
-
-				if (elasticInfrastructureCfg.isPresent()) {
-					final Calculator calculator = this.setupNumberOfElementsCalculator(resourceContainerMeasuringPoint,
-							this.calculatorFactory, elasticInfrastructureCfg.get());
-					return Result.of(new CalculatorRegistered(calculator));
-				}
+				final Calculator calculator = this.setupNumberOfElementsCalculator(resourceContainerMeasuringPoint,
+						this.calculatorFactory, resourceContainerMeasuringPoint.getElasticInfrastructureCfg());
+				return Result.of(new CalculatorRegistered(calculator));
 			}
 		}
 

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/monitor/NumberOfElementsMonitorBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/monitor/NumberOfElementsMonitorBehavior.java
@@ -38,18 +38,14 @@ import org.palladiosimulator.spdmeasuringpoint.SPDResourceContainerMeasuringPoin
  * Behavior to monitor the number of elements in a Elastic Infrastructure.
  *
  * The behavior creates Probes and Calculators for
- * {@link ResourceContainerMeasuringPoint}s. Beware it does *not* react to
- * {@link ResourceEnvironmentMeasuringPoint}s, as we cannot determine the target
- * group configuration from that measuring point.
+ * {@link SPDResourceContainerMeasuringPoint}s.
  *
- * For a {@link ResourceContainerMeasuringPoint}, the behavior creates a probe
- * and a calculator for the given resource container, iff the resource container
- * is {@code unit} in any of the given target configurations.
+ * For a {@link SPDResourceContainerMeasuringPoint}, the behavior creates a
+ * probe and a calculator for the given resource container, iff the resource
+ * container is {@code unit} in any of the given target configurations.
  *
  * The metric specification must be the base metric "number of resource
  * containers".
- *
- *
  *
  * @author Sarah Stieß
  *

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/monitor/NumberOfElementsMonitorBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/monitor/NumberOfElementsMonitorBehavior.java
@@ -49,12 +49,6 @@ import org.palladiosimulator.spdmeasuringpoint.SPDResourceContainerMeasuringPoin
  * The metric specification must be the base metric "number of resource
  * containers".
  *
- * Beware : this behaviour is only a temporary workaround. In the future there
- * should be a afor a target group. In that way the modeller knows that the
- * measuring point is bound to the concepts that SPD contributes. In the current
- * way the modeller is unaware that the combination MP on the Resource Container
- * and the metric Number of Resource Container is valid only when the SPD
- * extension is active in Slingshot.
  *
  *
  * @author Sarah Stieß

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/META-INF/MANIFEST.MF
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/META-INF/MANIFEST.MF
@@ -17,4 +17,7 @@ Require-Bundle: org.palladiosimulator.analyzer.slingshot.core,
  org.palladiosimulator.analyzer.slingshot.monitor;bundle-version="1.0.0",
  org.palladiosimulator.analyzer.slingshot.behavior.usagesimulation.data,
  org.palladiosimulator.pcm.edp2.measuringpoint;bundle-version="5.1.0",
- org.palladiosimulator.analyzer.slingshot.common.utils
+ org.palladiosimulator.analyzer.slingshot.common.utils,
+ org.palladiosimulator.spd.semantic,
+ org.palladiosimulator.spd.measuringpoint;bundle-version="1.0.0",
+ org.palladiosimulator.analyzer.slingshot.behavior.spd.data;bundle-version="1.0.0"

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/NumberOfElementsMonitorBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/NumberOfElementsMonitorBehavior.java
@@ -1,0 +1,198 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.ModelAdjusted;
+import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor.probes.NumberOfElementsInCompetingConsumerGroupProbe;
+import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor.probes.NumberOfElementsInServiceGroupProbe;
+import org.palladiosimulator.analyzer.slingshot.common.annotations.Nullable;
+import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorExtension;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.Subscribe;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.eventcontract.EventCardinality;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.eventcontract.OnEvent;
+import org.palladiosimulator.analyzer.slingshot.eventdriver.returntypes.Result;
+import org.palladiosimulator.analyzer.slingshot.monitor.data.entities.ProbeTakenEntity;
+import org.palladiosimulator.analyzer.slingshot.monitor.data.events.CalculatorRegistered;
+import org.palladiosimulator.analyzer.slingshot.monitor.data.events.ProbeTaken;
+import org.palladiosimulator.analyzer.slingshot.monitor.data.events.modelvisited.MeasurementSpecificationVisited;
+import org.palladiosimulator.analyzer.slingshot.monitor.data.events.modelvisited.MonitorModelVisited;
+import org.palladiosimulator.edp2.models.measuringpoint.MeasuringPoint;
+import org.palladiosimulator.edp2.util.MetricDescriptionUtility;
+import org.palladiosimulator.metricspec.constants.MetricDescriptionConstants;
+import org.palladiosimulator.monitorrepository.MeasurementSpecification;
+import org.palladiosimulator.pcm.core.composition.AssemblyContext;
+import org.palladiosimulator.probeframework.calculator.Calculator;
+import org.palladiosimulator.probeframework.calculator.DefaultCalculatorProbeSets;
+import org.palladiosimulator.probeframework.calculator.IGenericCalculatorFactory;
+import org.palladiosimulator.semanticspd.CompetingConsumersGroupCfg;
+import org.palladiosimulator.semanticspd.Configuration;
+import org.palladiosimulator.semanticspd.ServiceGroupCfg;
+import org.palladiosimulator.spdmeasuringpoint.SPDAssemblyContextMeasuringPoint;
+
+/**
+ *
+ * Behavior to monitor the number of elements in a Service Group or a Competing
+ * Consumer Group.
+ *
+ * The behavior creates Probes and Calculators for
+ * {@link SPDAssemblyContextMeasuringPoint}s.
+ *
+ * For an {@link SPDAssemblyContextMeasuringPoint}, the behavior creates a probe
+ * and a calculator for the given assembly context, iff the resource container
+ * is {@code unit} in any of the given target configurations.
+ *
+ * TODO fixme : Currently, the metric specification must be the base metric
+ * "number of resource containers" which is semantically completly wron but
+ * still works, becasuse its pain numbers.
+ *
+ *
+ * @author Sarah Stieß
+ *
+ */
+@OnEvent(when = MonitorModelVisited.class, then = CalculatorRegistered.class, cardinality = EventCardinality.SINGLE)
+@OnEvent(when = ModelAdjusted.class, then = ProbeTaken.class, cardinality = EventCardinality.SINGLE)
+public class NumberOfElementsMonitorBehavior implements SimulationBehaviorExtension {
+
+	private final IGenericCalculatorFactory calculatorFactory;
+	private final Configuration semanticConfiguration;
+
+	private final Map<AssemblyContext, NumberOfElementsInServiceGroupProbe> serviceGroupProbes = new HashMap<>();
+	private final Map<AssemblyContext, NumberOfElementsInCompetingConsumerGroupProbe> competingConsumerProbes = new HashMap<>();
+
+	@Inject
+	public NumberOfElementsMonitorBehavior(final IGenericCalculatorFactory calculatorFactory,
+			final @Nullable Configuration semanticConfiguration) {
+		this.calculatorFactory = calculatorFactory;
+		this.semanticConfiguration = semanticConfiguration;
+	}
+
+	@Override
+	public boolean isActive() {
+		return this.semanticConfiguration != null;
+	}
+
+	@Subscribe
+	public Result<CalculatorRegistered> onMeasurementSpecification(final MeasurementSpecificationVisited m) {
+		final MeasurementSpecification spec = m.getEntity();
+		final MeasuringPoint measuringPoint = spec.getMonitor().getMeasuringPoint();
+
+		if (measuringPoint instanceof SPDAssemblyContextMeasuringPoint) {
+			// Assmebly MP --> register probe for Target groups where assembly is unit
+			final SPDAssemblyContextMeasuringPoint assemblyContextMeasuringPoint = (SPDAssemblyContextMeasuringPoint) measuringPoint;
+
+			if (MetricDescriptionUtility.metricDescriptionIdsEqual(spec.getMetricDescription(),
+					MetricDescriptionConstants.NUMBER_OF_RESOURCE_CONTAINERS)) { // TODO Fix Metric description
+
+				final Set<CalculatorRegistered> calculatorRegisteredEvents = new HashSet<>();
+
+				final Optional<Calculator> sgCalculator = regsterSGCalculator(assemblyContextMeasuringPoint);
+				final Optional<Calculator> ccgCalculator = registerCCGCalculator(assemblyContextMeasuringPoint);
+
+				sgCalculator.ifPresent((calc) -> calculatorRegisteredEvents.add(new CalculatorRegistered(calc)));
+				ccgCalculator.ifPresent((calc) -> calculatorRegisteredEvents.add(new CalculatorRegistered(calc)));
+
+				return Result.of(calculatorRegisteredEvents);
+			}
+		}
+
+		return Result.empty();
+	}
+
+	/**
+	 * Register a Calculator if the AssemblyContext of the given MP is a
+	 * {@code unit} in a {@link ServiceGroupCfg}.
+	 *
+	 * @param assemblyContextMeasuringPoint MP to register a calculator for
+	 * @return the calculator, iff it got registered
+	 */
+	private Optional<Calculator> registerCCGCalculator(
+			final SPDAssemblyContextMeasuringPoint assemblyContextMeasuringPoint) {
+		final Optional<CompetingConsumersGroupCfg> competingConsumerGroupCfg = this.semanticConfiguration
+				.getTargetCfgs().stream().filter(cfg -> (cfg instanceof CompetingConsumersGroupCfg))
+				.map(eicfg -> ((CompetingConsumersGroupCfg) eicfg))
+				.filter(eicfg -> eicfg.getUnit().getId().equals(assemblyContextMeasuringPoint.getAssembly().getId()))
+				.findAny();
+
+		if (competingConsumerGroupCfg.isPresent()) {
+			final Calculator calculator = this.setupNumberOfElementsCalculator(assemblyContextMeasuringPoint,
+					this.calculatorFactory, competingConsumerGroupCfg.get());
+			return Optional.of(calculator);
+		}
+		return Optional.empty();
+	}
+
+	/**
+	 * Register a Calculator if the AssemblyContext of the given MP is a
+	 * {@code unit} in a {@link CompetingConsumersGroupCfg}.
+	 *
+	 * @param assemblyContextMeasuringPoint MP to register a calculator for
+	 * @return the calculator, iff it got registered
+	 */
+	private Optional<Calculator> regsterSGCalculator(
+			final SPDAssemblyContextMeasuringPoint assemblyContextMeasuringPoint) {
+		final Optional<ServiceGroupCfg> serviceGroupCfg = this.semanticConfiguration.getTargetCfgs().stream()
+				.filter(cfg -> (cfg instanceof ServiceGroupCfg)).map(eicfg -> ((ServiceGroupCfg) eicfg))
+				.filter(eicfg -> eicfg.getUnit().getId().equals(assemblyContextMeasuringPoint.getAssembly().getId()))
+				.findAny();
+
+		if (serviceGroupCfg.isPresent()) {
+			final Calculator calculator = this.setupNumberOfElementsCalculator(assemblyContextMeasuringPoint,
+					this.calculatorFactory, serviceGroupCfg.get());
+			return Optional.of(calculator);
+		}
+		return Optional.empty();
+	}
+
+	@Subscribe
+	public Result<ProbeTaken> onModelAdjusted(final ModelAdjusted stateUpdated) {
+		final Set<ProbeTaken> probesTaken = new HashSet<>();
+
+		for (final NumberOfElementsInServiceGroupProbe probe : serviceGroupProbes.values()) {
+			probe.takeMeasurement(stateUpdated);
+			probesTaken.add(new ProbeTaken(ProbeTakenEntity.builder().withProbe(probe).build()));
+		}
+
+		for (final NumberOfElementsInCompetingConsumerGroupProbe probe : competingConsumerProbes.values()) {
+			probe.takeMeasurement(stateUpdated);
+			probesTaken.add(new ProbeTaken(ProbeTakenEntity.builder().withProbe(probe).build()));
+		}
+		return Result.of(probesTaken);
+	}
+
+	/**
+	 *
+	 * @param measuringPoint
+	 * @param calculatorFactory
+	 * @param sgCfg
+	 * @return the new calculator
+	 */
+	public Calculator setupNumberOfElementsCalculator(final MeasuringPoint measuringPoint,
+			final IGenericCalculatorFactory calculatorFactory, final ServiceGroupCfg sgCfg) {
+		this.serviceGroupProbes.putIfAbsent(sgCfg.getUnit(), new NumberOfElementsInServiceGroupProbe(sgCfg));
+		final NumberOfElementsInServiceGroupProbe probe = this.serviceGroupProbes.get(sgCfg.getUnit());
+		return calculatorFactory.buildCalculator(MetricDescriptionConstants.NUMBER_OF_RESOURCE_CONTAINERS_OVER_TIME,
+				measuringPoint, DefaultCalculatorProbeSets.createSingularProbeConfiguration(probe));
+	}
+
+	/**
+	 *
+	 * @param measuringPoint
+	 * @param calculatorFactory
+	 * @param sgCfg
+	 * @return the new calculator
+	 */
+	public Calculator setupNumberOfElementsCalculator(final MeasuringPoint measuringPoint,
+			final IGenericCalculatorFactory calculatorFactory, final CompetingConsumersGroupCfg sgCfg) {
+		this.competingConsumerProbes.putIfAbsent(sgCfg.getUnit(),
+				new NumberOfElementsInCompetingConsumerGroupProbe(sgCfg));
+		final NumberOfElementsInCompetingConsumerGroupProbe probe = this.competingConsumerProbes.get(sgCfg.getUnit());
+		return calculatorFactory.buildCalculator(MetricDescriptionConstants.NUMBER_OF_RESOURCE_CONTAINERS_OVER_TIME,
+				measuringPoint, DefaultCalculatorProbeSets.createSingularProbeConfiguration(probe));
+	}
+}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/NumberOfElementsMonitorBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/NumberOfElementsMonitorBehavior.java
@@ -73,7 +73,7 @@ public class NumberOfElementsMonitorBehavior implements SimulationBehaviorExtens
 
 	@Override
 	public boolean isActive() {
-		return this.semanticConfiguration != null;
+		return this.semanticConfiguration != null && !this.semanticConfiguration.getTargetCfgs().isEmpty();
 	}
 
 	@Subscribe

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/SystemModelMonitorModule.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/SystemModelMonitorModule.java
@@ -7,6 +7,6 @@ public class SystemModelMonitorModule extends AbstractSlingshotExtension {
 	@Override
 	protected void configure() {
 		install(OperationCallActionResponseTimeMonitoringBehavior.class);
+		install(NumberOfElementsMonitorBehavior.class);
 	}
-
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/probes/NumberOfElementsInCompetingConsumerGroupProbe.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/probes/NumberOfElementsInCompetingConsumerGroupProbe.java
@@ -1,0 +1,44 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor.probes;
+
+import javax.measure.Measure;
+import javax.measure.quantity.Dimensionless;
+import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
+import org.palladiosimulator.analyzer.slingshot.monitor.probes.EventBasedListProbe;
+import org.palladiosimulator.metricspec.constants.MetricDescriptionConstants;
+import org.palladiosimulator.semanticspd.CompetingConsumersGroupCfg;
+
+/**
+ * Probe for the Number of Elements in a Competing Consumer Group.
+ *
+ * The Number of Elements is always calculated with regard to a certain target
+ * group configuration, i.e. only elements of a given target group are
+ * considered.
+ *
+ * @author Sarah Stieß
+ *
+ */
+public final class NumberOfElementsInCompetingConsumerGroupProbe extends EventBasedListProbe<Long, Dimensionless> {
+
+	private final CompetingConsumersGroupCfg competingConsumerGroupConfiguration;
+
+	/**
+	 * Constructor for NumberOfElementsIncompetingConsumerGroupProbe.
+	 *
+	 * TODO : fix metric description !!
+	 *
+	 * @param competingConsumerGroupCfg configuration of target group that will be
+	 *                                  measured.
+	 */
+	public NumberOfElementsInCompetingConsumerGroupProbe(
+			final CompetingConsumersGroupCfg competingConsumerGroupCfg) {
+		super(MetricDescriptionConstants.NUMBER_OF_RESOURCE_CONTAINERS_OVER_TIME);
+		// yes, this one subsumes
+		this.competingConsumerGroupConfiguration = competingConsumerGroupCfg;
+	}
+
+	@Override
+	public Measure<Long, Dimensionless> getMeasurement(final DESEvent event) {
+		return Measure.valueOf(Long.valueOf(competingConsumerGroupConfiguration.getElements().size()),
+				Dimensionless.UNIT);
+	}
+}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/probes/NumberOfElementsInServiceGroupProbe.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/probes/NumberOfElementsInServiceGroupProbe.java
@@ -1,0 +1,43 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor.probes;
+
+import javax.measure.Measure;
+import javax.measure.quantity.Dimensionless;
+import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
+import org.palladiosimulator.analyzer.slingshot.monitor.probes.EventBasedListProbe;
+import org.palladiosimulator.metricspec.constants.MetricDescriptionConstants;
+import org.palladiosimulator.semanticspd.ServiceGroupCfg;
+
+/**
+ * Probe for the Number of Elements in a Service Group.
+ *
+ * The Number of Elements is always calculated with regard to a certain target
+ * group configuration, i.e. only elements of a given target group are
+ * considered.
+ *
+ * @author Sarah Stieß
+ *
+ */
+public final class NumberOfElementsInServiceGroupProbe extends EventBasedListProbe<Long, Dimensionless> {
+
+	private final ServiceGroupCfg serviceGroupConfiguration;
+
+	/**
+	 * Constructor for NumberOfElementsInServiceGroupProbe.
+	 *
+	 * TODO : fix metric description !!
+	 *
+	 * @param serviceGroupCfg configuration of target group that will be measured.
+	 */
+	public NumberOfElementsInServiceGroupProbe(
+			final ServiceGroupCfg serviceGroupCfg) {
+		super(MetricDescriptionConstants.NUMBER_OF_RESOURCE_CONTAINERS_OVER_TIME);
+		// yes, this one subsumes
+		this.serviceGroupConfiguration = serviceGroupCfg;
+	}
+
+	@Override
+	public Measure<Long, Dimensionless> getMeasurement(final DESEvent event) {
+		return Measure.valueOf(Long.valueOf(serviceGroupConfiguration.getElements().size()),
+				Dimensionless.UNIT);
+	}
+}


### PR DESCRIPTION
## Current Behaviour

Number of Elements Monitoring Behaviour for Resource Container is based on the general PCM Resource Container MP.
Number of Elements Monitoring Behaviours for SG and CCG do not exist. 

## New Behaviour

Number of Elements Monitoring Behaviour for Resource Container is based on the SPD specific Resource Container MP (c.f. PalladioSimulator/Palladio-Addons-SPD-Metamodel#19) and require the SPD specific MPs to be merged first. 
Number of Elements Monitoring Behaviour for SG and CCG does exist.

## Misc
*Beware*: There is no metric description for numers of assembly, thus the implementation of the behaviours uses the number of resource container, which is plain wrong but stil works because it's numbers without any unit. 

Tested on SG and EI, and it worked. 
Not tested on CCG, becaus i forgot how to model CCGs.

This PR will close #44 and it will close #41.  