### PR TITLE
Creating Passive Resources for newly created allocations

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/ResourceSimulation.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/ResourceSimulation.java
@@ -2,12 +2,8 @@ package org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation;
 
 import static org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.eventcontract.EventCardinality.SINGLE;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
@@ -16,13 +12,6 @@ import java.util.UUID;
 import javax.inject.Inject;
 
 import org.apache.log4j.Logger;
-import org.eclipse.emf.common.util.URI;
-import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.emf.ecore.resource.ResourceSet;
-import org.eclipse.emf.ecore.resource.impl.ResourceImpl;
-import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
-import org.eclipse.emf.ecore.xmi.XMLResource;
-import org.eclipse.emf.ecore.xmi.impl.XMLResourceFactoryImpl;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.jobs.ActiveJob;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.jobs.Job;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.jobs.LinkingJob;
@@ -401,40 +390,8 @@ public class ResourceSimulation implements SimulationBehaviorExtension {
 	 */
 	@Subscribe
 	public void onSimulationFinished(final SimulationFinished simulationFinished) {
-		setupAndSaveResourceModel();
-
 		this.resourceTable.clearResourcesFromJobs();
 		this.passiveResourceTable.clearResourcesFromJobs();
 		this.linkingResourceTable.clearResourcesFromJobs();
-	}
-
-	/*
-	 * Only for debugging!
-	 */
-	private void setupAndSaveResourceModel() {
-		final ResourceSet rs = new ResourceSetImpl();
-		final Resource reResource = createResource("platform:/resource/RemoteMeasuringMosaic/rm_output.resourceenvironment", rs);
-		reResource.getContents().add(allocation.getTargetResourceEnvironment_Allocation());
-		saveResource(reResource);
-	}
-
-	private Resource createResource(final String outputFile, final ResourceSet rs) {
-		rs.getResourceFactoryRegistry().getExtensionToFactoryMap().put("resourceenvironment", new XMLResourceFactoryImpl());
-		final URI uri = URI.createURI(outputFile);
-		final Resource resource = rs.createResource(uri);
-		((ResourceImpl) resource).setIntrinsicIDToEObjectMap(new HashMap<>());
-		return resource;
-	}
-
-	private void saveResource(final Resource resource) {
-		final Map saveOptions = ((XMLResource) resource).getDefaultSaveOptions();
-		saveOptions.put(XMLResource.OPTION_CONFIGURATION_CACHE, Boolean.TRUE);
-		saveOptions.put(XMLResource.OPTION_USE_CACHED_LOOKUP_TABLE, new ArrayList<>());
-
-		try {
-			resource.save(saveOptions);
-		} catch (final IOException e) {
-			LOGGER.error(e);
-		}
 	}
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/ResourceSimulation.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/ResourceSimulation.java
@@ -34,6 +34,7 @@ import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.reso
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.resources.passive.PassiveResourceTable;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.resources.passive.SimplePassiveResource;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.ModelAdjusted;
+import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.adjustment.AllocationChange;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.adjustment.ResourceEnvironmentChange;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.resource.CallOverWireRequest;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.resource.ResourceDemandRequest;
@@ -322,9 +323,18 @@ public class ResourceSimulation implements SimulationBehaviorExtension {
 								 .map(ResourceEnvironmentChange.class::cast)
 								 .forEach(this::changeActiveResourceTableFromModelChange);
 
+		
+		modelChanged.getChanges().stream().filter(change -> change instanceof AllocationChange)
+								.map(AllocationChange.class::cast)
+								.forEach(this::changePassiveResources);
+		
 		return Result.empty();
 	}
 
+	private void changePassiveResources(AllocationChange allocationchange1) {
+		this.passiveResourceTable.buildPassiveResources(allocationchange1.getNewAllocationContexts());
+	}
+	
 	private void changeActiveResourceTableFromModelChange(final ResourceEnvironmentChange change) {
 		change.getNewResourceContainers().forEach(newContainer ->
 			this.resourceTable.createActiveResourcesFromResourceContainer(newContainer));

--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/passive/PassiveResourceTable.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/resources/passive/PassiveResourceTable.java
@@ -1,5 +1,6 @@
 package org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.resources.passive;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.resources.IPassiveResource;
@@ -7,6 +8,7 @@ import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.enti
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.resources.AbstractResourceTable;
 import org.palladiosimulator.pcm.allocation.Allocation;
 import org.palladiosimulator.pcm.allocation.AllocationContext;
+import org.palladiosimulator.pcm.allocation.util.AllocationSwitch;
 import org.palladiosimulator.pcm.core.composition.AssemblyContext;
 import org.palladiosimulator.pcm.repository.BasicComponent;
 import org.palladiosimulator.pcm.repository.PassiveResource;
@@ -92,5 +94,18 @@ public final class PassiveResourceTable
 			final PassiveResource passiveResource, final AssemblyContext assemblyContext) {
 		final PassiveResourceCompoundKey key = PassiveResourceCompoundKey.of(passiveResource, assemblyContext);
 		return this.getPassiveResource(key);
+	}
+
+	/**
+	 * Helper method to build PassiveResources for newly created allocation contexts.
+	 * 
+	 * @param newAllocations
+	 */
+	public void buildPassiveResources(List<AllocationContext> newAllocations) {
+		newAllocations.stream().map(AllocationContext::getAssemblyContext_AllocationContext)
+		.filter(allocationContext -> allocationContext
+				.getEncapsulatedComponent__AssemblyContext() instanceof BasicComponent)
+		.forEach(this::createPassiveResources);
+		
 	}
 }


### PR DESCRIPTION
- First implementation of the linking resource
- Make the simulation aware that linking resources exist, and distinguish active jobs from linking jobs
- Calculate the demand correctly from the user
- Make that the SEFF waits for the response of the linking resource, so that time advanced
- Already put latency upon initiation of the job
- Add latency after the throughput was considered
- Make also a return call after the external execution has finished
- Also make return calls but only with the output variables
- Rename ExternalCallRequested -> CallOverWireRequested
- minor style fix
- Make also child context for branch actions
- Fix infrastructure call
- Fix usage monitor
- remove debug operations from resource simulation.
- move helpers to Utils class.
- creating passive resources upon new allocations got created
