### PR TITLE
Fix the monitoring of response time for operation calls

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/OperationCallActionResponseTimeMonitoringBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/OperationCallActionResponseTimeMonitoringBehavior.java
@@ -157,7 +157,13 @@ public class OperationCallActionResponseTimeMonitoringBehavior implements Simula
 		private static RequestContext passedElement(final DESEvent desEvent) {
 			if (desEvent instanceof SEFFModelPassedElement<?>) {
 				final SEFFModelPassedElement<?> el = (SEFFModelPassedElement<?>) desEvent;
-				return new RequestContext(el.getContext().getRequestProcessingContext().getUser().getId());
+				
+				if(el.getContext().getCaller().isPresent()) {
+					return new RequestContext(el.getContext().getRequestProcessingContext().getUser().getId()+el.getContext().getCaller().get().hashCode());
+				} else {
+					return new RequestContext(el.getContext().getRequestProcessingContext().getUser().getId());	
+				}
+				
 			}
 			return RequestContext.EMPTY_REQUEST_CONTEXT;
 		}


### PR DESCRIPTION
This PR fixes https://github.com/PalladioSimulator/Palladio-Analyzer-Slingshot-Extension-PCM-Core/issues/53. Refer to the issue for the description. 

The fix includes the caller context in case it exists. If not, it uses only the user context. Since each forked beahvior ends up in a new interpretation context, the request context is uniqely identified with the user and the hashCode of the calling interpretation context.