### PR TITLE
Abortion of requests in case of changes

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/ResourceSimulation.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/ResourceSimulation.java
@@ -4,7 +4,6 @@ import static org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.e
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -119,7 +118,7 @@ public class ResourceSimulation implements SimulationBehaviorExtension {
 		final ResourceDemandRequest request = resourceDemandRequested.getEntity();
 
 		if (request.getResourceType() == ResourceType.ACTIVE) {
-			return this.initiateActiveResource(request);
+			return Result.of(initiateActiveResource(request));
 		}
 		return Result.of(this.initiatePassiveResource(request));
 	}
@@ -148,7 +147,7 @@ public class ResourceSimulation implements SimulationBehaviorExtension {
 	 * @param request
 	 * @return
 	 */
-	private Result<AbstractSimulationEvent> initiateActiveResource(final ResourceDemandRequest request) {
+	private Set<AbstractSimulationEvent> initiateActiveResource(final ResourceDemandRequest request) {
 		final double demand = StackContext.evaluateStatic(
 				request.getParametricResourceDemand().getSpecification_ParametericResourceDemand().getSpecification(),
 				Double.class, request.getUser().getStack().currentStackFrame());
@@ -162,7 +161,7 @@ public class ResourceSimulation implements SimulationBehaviorExtension {
 					.withProcessingResourceType(
 							request.getParametricResourceDemand().getRequiredResource_ParametricResourceDemand())
 					.withRequest(request).build();
-			return Result.of(new JobAborted(job, 0));
+			return Set.of(new JobAborted(job, 0));
 		}
 
 		final Job job = ActiveJob.builder().withDemand(demand).withId(UUID.randomUUID().toString())
@@ -170,7 +169,7 @@ public class ResourceSimulation implements SimulationBehaviorExtension {
 						request.getParametricResourceDemand().getRequiredResource_ParametricResourceDemand())
 				.withRequest(request).withAllocationContext(context.get()).build();
 
-		return Result.of(new JobInitiated(job, 0));
+		return Set.of(new JobInitiated(job, 0));
 	}
 
 	/**

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/events/ResourceDemandRequestAborted.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/events/ResourceDemandRequestAborted.java
@@ -1,0 +1,12 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events;
+
+import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.resource.ResourceDemandRequest;
+
+public class ResourceDemandRequestAborted extends AbstractResourceRequestEvent {
+
+	public ResourceDemandRequestAborted(ResourceDemandRequest entity) {
+		super(entity, 0);
+		// TODO Auto-generated constructor stub
+	}
+
+}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.usagesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/usagemodel/events/UserAborted.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.usagesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/usagemodel/events/UserAborted.java
@@ -1,0 +1,21 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.events;
+
+import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.entities.interpretationcontext.UserInterpretationContext;
+import org.palladiosimulator.pcm.usagemodel.Stop;
+
+/**
+ * This event indicates that the user has been aborted during the simulation. It
+ * marks out the case in which the interpretation for a user could not proceed
+ * due to changes in the model.
+ * 
+ * @author Floriment Klinaku
+ *
+ */
+public class UserAborted extends AbstractUserChangedEvent {
+
+	public UserAborted(UserInterpretationContext entity) {
+		super(entity, 0);
+		// TODO Auto-generated constructor stub
+	}
+
+}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.usagesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/usagesimulation/UsageSimulationBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.usagesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/usagesimulation/UsageSimulationBehavior.java
@@ -386,13 +386,12 @@ public class UsageSimulationBehavior implements SimulationBehaviorExtension {
 		context.getUser().getStack().removeStackFrame();
 //		this.startUsageSimulation(resultSet);
 		/*
-		 * Error in Semantics before with the above statement: - For OpenWorkloads,
-		 * another user will be spawned which is already done by the
-		 * InterArrivalUserInitiated event. - For ClosedWorkloads, old users will be
-		 * replaced with new users, which is not exactly "re-entering" and it is harder
-		 * to let them only spawn after a ThinkTime. Instead, only for
-		 * ClosedWorkloadUsers, let them re-enter the system after the ThinkTime. For
-		 * OpenWorkloadUsers, this is already handled in the other event.
+		 * Error in Semantics before with the above statement:
+		 *  - For OpenWorkloads, another user will be spawned which is already done by the InterArrivalUserInitiated event.
+		 *  - For ClosedWorkloads, old users will be replaced with new users, which is not exactly "re-entering" and it is
+		 *    harder to let them only spawn after a ThinkTime.
+		 * Instead, only for ClosedWorkloadUsers, let them re-enter the system after the ThinkTime.
+		 * For OpenWorkloadUsers, this is already handled in the other event.
 		 */
 		if (context instanceof ClosedWorkloadUserInterpretationContext) {
 			final ClosedWorkloadUserInterpretationContext closedContext = (ClosedWorkloadUserInterpretationContext) context;

--- a/org.palladiosimulator.analyzer.slingshot.behavior.usagesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/usagesimulation/UsageSimulationBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.usagesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/usagesimulation/UsageSimulationBehavior.java
@@ -25,6 +25,7 @@ import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.events.Inter
 import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.events.UsageModelPassedElement;
 import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.events.UsageScenarioFinished;
 import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.events.UsageScenarioStarted;
+import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.events.UserAborted;
 import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.events.UserEntryRequested;
 import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.events.UserFinished;
 import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.events.UserRequestFinished;
@@ -58,12 +59,15 @@ import com.google.common.collect.ImmutableList;
  *
  * @author Julijan Katic
  */
-@OnEvent(when = SimulationStarted.class, then = { UserStarted.class,
-		InterArrivalUserInitiated.class, UsageModelPassedElement.class }, cardinality = MANY)
+@OnEvent(when = SimulationStarted.class, then = { UserStarted.class, InterArrivalUserInitiated.class,
+		UsageModelPassedElement.class }, cardinality = MANY)
 @OnEvent(when = UserStarted.class, then = { UserFinished.class, UserEntryRequested.class, UserSlept.class,
 		UserWokeUp.class, InnerScenarioBehaviorInitiated.class, UsageScenarioStarted.class,
 		UsageModelPassedElement.class }, cardinality = MANY)
 @OnEvent(when = UserFinished.class, then = { UserStarted.class, InterArrivalUserInitiated.class,
+		ClosedWorkloadUserInitiated.class, UsageScenarioFinished.class, UserFinished.class, UserSlept.class,
+		UserWokeUp.class, UsageModelPassedElement.class }, cardinality = MANY)
+@OnEvent(when = UserAborted.class, then = { UserStarted.class, InterArrivalUserInitiated.class,
 		ClosedWorkloadUserInitiated.class, UsageScenarioFinished.class, UserFinished.class, UserSlept.class,
 		UserWokeUp.class, UsageModelPassedElement.class }, cardinality = MANY)
 @OnEvent(when = UserWokeUp.class, then = { UserFinished.class, UserEntryRequested.class, UserSlept.class,
@@ -99,8 +103,7 @@ public class UsageSimulationBehavior implements SimulationBehaviorExtension {
 	public void init() {
 		this.usageModelRepository.load(this.usageModel);
 		this.usageInterpretationContext = UsageInterpretationContext.builder()
-				.withUsageScenariosContexts(this.collectAllUsageScenarios())
-				.build();
+				.withUsageScenariosContexts(this.collectAllUsageScenarios()).build();
 	}
 
 	/**
@@ -132,8 +135,8 @@ public class UsageSimulationBehavior implements SimulationBehaviorExtension {
 		 * Because this is the first action, this should only contain the UserStarted
 		 * and InterArrivalUserInitiated events.
 		 */
-		//assert Postconditions.checkResultTypesAndSize(returnedEvents,
-		//		List.of(UserStarted.class, InterArrivalUserInitiated.class), 2);
+		// assert Postconditions.checkResultTypesAndSize(returnedEvents,
+		// List.of(UserStarted.class, InterArrivalUserInitiated.class), 2);
 
 		return Result.of(returnedEvents);
 	}
@@ -185,13 +188,9 @@ public class UsageSimulationBehavior implements SimulationBehaviorExtension {
 				.withScenarioBehavior(usageScenario.getScenarioBehaviour_UsageScenario()).build();
 
 		final OpenWorkloadUserInterpretationContext openWorkloadUserInterpretationContext = OpenWorkloadUserInterpretationContext
-				.builder()
-				.withUser(new User())
-				.withScenario(usageScenario)
-				.withCurrentAction(firstAction)
+				.builder().withUser(new User()).withScenario(usageScenario).withCurrentAction(firstAction)
 				.withInterArrivalTime(new InterArrivalTime(interArrivalRV))
-				.withUsageScenarioBehaviorContext(scenarioContext)
-				.build();
+				.withUsageScenarioBehaviorContext(scenarioContext).build();
 
 		final UsageScenarioInterpreter interpreter = new UsageScenarioInterpreter(
 				openWorkloadUserInterpretationContext);
@@ -220,20 +219,16 @@ public class UsageSimulationBehavior implements SimulationBehaviorExtension {
 		assert usageScenario.getWorkload_UsageScenario() instanceof ClosedWorkload;
 
 		final RootScenarioContext scenarioContext = RootScenarioContext.builder()
-				.withScenarioBehavior(usageScenario.getScenarioBehaviour_UsageScenario())
-				.build();
+				.withScenarioBehavior(usageScenario.getScenarioBehaviour_UsageScenario()).build();
 
 		final ClosedWorkload workloadSpec = (ClosedWorkload) usageScenario.getWorkload_UsageScenario();
 		final ClosedWorkloadUserInterpretationContext.Builder partialInterpretationBuilder = ClosedWorkloadUserInterpretationContext
-				.builder()
-				.withCurrentAction(firstAction)
+				.builder().withCurrentAction(firstAction)
 				.withThinkTime(new ThinkTime(workloadSpec.getThinkTime_ClosedWorkload()))
-				.withUsageScenarioBehaviorContext(scenarioContext)
-				.withScenario(usageScenario);
+				.withUsageScenarioBehaviorContext(scenarioContext).withScenario(usageScenario);
 
 		for (int i = 0; i < workloadSpec.getPopulation(); i++) {
-			final UserInterpretationContext interpretationContext = partialInterpretationBuilder
-					.withUser(new User())
+			final UserInterpretationContext interpretationContext = partialInterpretationBuilder.withUser(new User())
 					.build();
 
 			final UsageScenarioInterpreter interpreter = new UsageScenarioInterpreter(interpretationContext);
@@ -275,8 +270,7 @@ public class UsageSimulationBehavior implements SimulationBehaviorExtension {
 	 * @return The events of interpreting the first actions in each scenario.
 	 */
 	@Subscribe
-	public Result<DESEvent> onInterArrivalUserInitiated(
-			final InterArrivalUserInitiated interArrivalUserInitiated) {
+	public Result<DESEvent> onInterArrivalUserInitiated(final InterArrivalUserInitiated interArrivalUserInitiated) {
 
 		final OpenWorkloadUserInterpretationContext openWorkloadUserInterpretationContext = (OpenWorkloadUserInterpretationContext) interArrivalUserInitiated
 				.getEntity();
@@ -337,18 +331,19 @@ public class UsageSimulationBehavior implements SimulationBehaviorExtension {
 	public Result<DESEvent> onUserFinished(final UserFinished evt) {
 		this.LOGGER.info("User finished: " + evt.getEntity());
 
-		final Set<DESEvent> resultSet = new HashSet<>();
 		final UserInterpretationContext context = evt.getEntity();
+		return finishUser(context);
+	}
 
+	private Result<DESEvent> finishUser(final UserInterpretationContext context) {
+		final Set<DESEvent> resultSet = new HashSet<>();
 		if (context.getParentContext().isPresent()) {
 			/* We are inside another behavior, such as loop or branch */
 			final UsageScenarioBehaviorContext scenarioBehaviorContext = context.getBehaviorContext();
 			final UserInterpretationContext newContext;
 
 			if (scenarioBehaviorContext.mustRepeatScenario()) {
-				newContext = context.update()
-						.withCurrentAction(scenarioBehaviorContext.startScenario())
-						.build();
+				newContext = context.update().withCurrentAction(scenarioBehaviorContext.startScenario()).build();
 			} else {
 				newContext = context.getParentContext().get()
 						.updateAction(scenarioBehaviorContext.getNextAction().get());
@@ -364,6 +359,23 @@ public class UsageSimulationBehavior implements SimulationBehaviorExtension {
 	}
 
 	/**
+	 * In case the user has been aborted, we finish the user and let the usage
+	 * simulation continue. The same behavior occurs in case of a
+	 * UserFinished event. The only difference is that from the perspective of other
+	 * extensions, the User did not successfully complete.
+	 * 
+	 * @param evt
+	 * @return
+	 */
+	@Subscribe
+	public Result<DESEvent> onUserAborted(final UserAborted evt) {
+		this.LOGGER.info("User aborted, lets restart, user: " + evt.getEntity());
+
+		final UserInterpretationContext context = evt.getEntity();
+		return finishUser(context);
+	}
+
+	/**
 	 * Helper method which lets the user rerun the simulation again as long as the
 	 * simulation hasn't been interrupted yet.
 	 *
@@ -374,12 +386,13 @@ public class UsageSimulationBehavior implements SimulationBehaviorExtension {
 		context.getUser().getStack().removeStackFrame();
 //		this.startUsageSimulation(resultSet);
 		/*
-		 * Error in Semantics before with the above statement:
-		 *  - For OpenWorkloads, another user will be spawned which is already done by the InterArrivalUserInitiated event.
-		 *  - For ClosedWorkloads, old users will be replaced with new users, which is not exactly "re-entering" and it is
-		 *    harder to let them only spawn after a ThinkTime.
-		 * Instead, only for ClosedWorkloadUsers, let them re-enter the system after the ThinkTime.
-		 * For OpenWorkloadUsers, this is already handled in the other event.
+		 * Error in Semantics before with the above statement: - For OpenWorkloads,
+		 * another user will be spawned which is already done by the
+		 * InterArrivalUserInitiated event. - For ClosedWorkloads, old users will be
+		 * replaced with new users, which is not exactly "re-entering" and it is harder
+		 * to let them only spawn after a ThinkTime. Instead, only for
+		 * ClosedWorkloadUsers, let them re-enter the system after the ThinkTime. For
+		 * OpenWorkloadUsers, this is already handled in the other event.
 		 */
 		if (context instanceof ClosedWorkloadUserInterpretationContext) {
 			final ClosedWorkloadUserInterpretationContext closedContext = (ClosedWorkloadUserInterpretationContext) context;


### PR DESCRIPTION
### Behavior before

When the model is adjusted, for example, when SPD is active, the PCM is transformed, i.e., a resource container (allocation) that existed previously does not exist anymore. Such changes require to handle events that are already scheduled with requests requiring the deleted model elements. 

### New behavior

We introduce events in corresponding extensions to mark abortion of requests: a) in the resource simulation, we mark the inability to continue the processing of a job with a JobAborted event, b) in the system simulation, we mark the inability to process a DemandRequestedEvent with DemandRequestAborted event, and ultimately c) in the user simulation, we mark the inability to process a user with a UserAborted event. 

This should resolve https://github.com/PalladioSimulator/Palladio-Analyzer-Slingshot-Extension-PCM-Core/issues/57#issue-2125201510. 
