### PR TITLE
Fix Assertion 

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.usagesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/usagesimulation/UsageSimulationBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.usagesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/usagesimulation/UsageSimulationBehavior.java
@@ -198,10 +198,6 @@ public class UsageSimulationBehavior implements SimulationBehaviorExtension {
 
 		final Set<DESEvent> events = interpreter.doSwitch(firstAction);
 
-		assert events.size() == 2;
-		assert events.stream().anyMatch(UserStarted.class::isInstance);
-		assert events.stream().anyMatch(InterArrivalUserInitiated.class::isInstance);
-
 		returnedEvents.addAll(events);
 	}
 
@@ -238,9 +234,6 @@ public class UsageSimulationBehavior implements SimulationBehaviorExtension {
 
 			final UsageScenarioInterpreter interpreter = new UsageScenarioInterpreter(interpretationContext);
 			final Set<DESEvent> events = interpreter.doSwitch(firstAction);
-
-			assert events.size() == 1;
-			assert events.stream().allMatch(UserStarted.class::isInstance);
 
 			returnedEvents.addAll(events);
 		}
@@ -289,11 +282,6 @@ public class UsageSimulationBehavior implements SimulationBehaviorExtension {
 		// interpretation
 
 		final Set<DESEvent> events = interpreter.doSwitch(firstAction);
-
-		assert events.size() == 3;
-		assert events.stream().anyMatch(UserStarted.class::isInstance);
-		assert events.stream().anyMatch(InterArrivalUserInitiated.class::isInstance);
-		assert events.stream().anyMatch(UsageModelPassedElement.class::isInstance);
 
 		return Result.of(events);
 	}


### PR DESCRIPTION
# Current

`UsageSimulationBehavior` has some overly specific `assert` statements, that check wrong conditions. They were probably correct at some point, but due to newly introduced events are now broken. 

# New
Deleted overly specific assertions. Could also have fixed them but decided against it, because in my opinion, the ContractChecker should be in charge of checking whether a subscriber emitts the correct events.

# Misc

Related to (not required for) https://github.com/PalladioSimulator/Palladio-Analyzer-Slingshot/pull/19 