### PR TITLE
Fix child SEFF IC

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/entities/seff/SEFFInterpretationContext.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/entities/seff/SEFFInterpretationContext.java
@@ -17,21 +17,6 @@ import de.uka.ipd.sdq.simucomframework.variables.stackframe.SimulatedStackframe;
  * The SEFFInterpretationContext is used for keeping track of the RDSeff
  * interpertation.
  *
- * Child contexts (i.e. nested SEFFs) always hold the caller
- * ({@code calledFrom}) of their parent context. However, only Root behaviours
- * should return to their callers. Others should return to their parent.
- *
- * Contexts have a non empty {@code callOverWireRequest} if they were called
- * from another context.
- *
- * A context's {@code callOverWireRequest} must <b>never</b> have their
- * {@code replyTo} set. If {@code replyTo} is set, it is a return to a caller,
- * and a return cannot be the calling request.
- *
- * TODO Children carry the {@code calledFrom} of their parents, but not their
- * {@code callOverWireRequest}. However i think, they should only appear
- * together. [S3]
- *
  * @author Julijan Katic, Sarah Stieß
  * @version 1.0
  */
@@ -44,12 +29,21 @@ public final class SEFFInterpretationContext {
 
 	private final AssemblyContext assemblyContext;
 
+	/**
+	 * Caller of this context. For a nested SEFF the caller is always equal to the
+	 * parent's caller.
+	 */
 	private final Optional<SEFFInterpretationContext> calledFrom;
+
+	/**
+	 * Request by which this SEFF was called. The requests must not be a
+	 * reply-request, as a reply-request cannot be used for calling anther SEFF.
+	 */
+	private final Optional<CallOverWireRequest> callOverWireRequest;
 
 	/** The parent context if this is a child context */
 	private final Optional<SEFFInterpretationContext> parent;
 
-	private final Optional<CallOverWireRequest> callOverWireRequest;
 
 	/**
 	 * The stackframe to hold the result variables of a call. This can be null,
@@ -63,7 +57,6 @@ public final class SEFFInterpretationContext {
 		assert builder.callOverWireRequest == null
 				|| (builder.callOverWireRequest != null && builder.calledFrom.isPresent())
 				: String.format("Missing caller in %s", this.getClass().getSimpleName());
-		// || (builder.callOverWireRequest == null && builder.calledFrom.isEmpty()):
 
 		this.calledFrom = builder.calledFrom;
 		this.behaviorContext = builder.behaviorContext;

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/entities/seff/SEFFInterpretationContext.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/entities/seff/SEFFInterpretationContext.java
@@ -193,11 +193,6 @@ public final class SEFFInterpretationContext {
 			return this;
 		}
 
-		public Builder withCaller(final SEFFInterpretationContext calledFrom) {
-			Optional.ofNullable(calledFrom);
-			return this;
-		}
-
 		public Builder withBehaviorContext(final SeffBehaviorContextHolder behaviorContext) {
 			this.behaviorContext = builderNonNull(behaviorContext);
 			return this;

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/entities/seff/SEFFInterpretationContext.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/entities/seff/SEFFInterpretationContext.java
@@ -87,14 +87,14 @@ public final class SEFFInterpretationContext {
 	/**
 	 * Returns the stack frame to which variables can be set. This can either be a
 	 * dedicated stack frame or the current stackframe from the user.
-	 * 
+	 *
 	 * If the result stack frame was set when constructing this context, then this
 	 * dedicated stack frame will be returned. Otherwise, the parent's
 	 * {@link #getCurrentResultStackframe()} will be returned.
-	 * 
+	 *
 	 * If the parent's stackframe are also {@code null}, the current user's stack
 	 * frame will be returned instead.
-	 * 
+	 *
 	 * @return A non-{@code null} stackframe object, either dedicated or the current
 	 *         user's stack frame.
 	 */
@@ -115,7 +115,7 @@ public final class SEFFInterpretationContext {
 	 * Creates a child context from this with empty fields, except that
 	 * {@link #getParent()} will point to this and
 	 * {@link #getRequestProcessingContext()} will stay the same.
-	 * 
+	 *
 	 * @return A builder for the child context.
 	 */
 	public Builder createChildContext() {
@@ -126,7 +126,7 @@ public final class SEFFInterpretationContext {
 	 * Creates a child context from this with the same values as this, except that
 	 * the result stack frame will be {@code null} since the result stack frame is
 	 * already set in the parent.
-	 * 
+	 *
 	 * @return A builder with pre-filled fields for the child context.
 	 */
 	public Builder createChildContextPrefilled() {
@@ -138,7 +138,7 @@ public final class SEFFInterpretationContext {
 				.withBehaviorContext(this.behaviorContext)
 				.withAssemblyContext(this.assemblyContext)
 				.withRequestProcessingContext(this.requestProcessingContext)
-				.withCaller(calledFrom)
+				.withCaller(this.calledFrom)
 				.withParent(this.parent.orElse(null))
 				.withCallOverWireRequest(this.callOverWireRequest.orElse(null))
 				.withResultStackframe(getCurrentResultStackframe());

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SeffSimulationBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SeffSimulationBehavior.java
@@ -46,7 +46,7 @@ public class SeffSimulationBehavior implements SimulationBehaviorExtension {
 
 		if (contextHolder instanceof InfrastructureCallsContextHolder) {
 			if (contextHolder.hasFinished()) {
-				// continue in parent -> a follow up SEFFInterpretationProgressed in the parent 
+				// continue in parent -> a follow up SEFFInterpretationProgressed in the parent
 				LOGGER.info("progression to parent of infra");
 				return Result.of(continueInParent(progressed.getEntity()));
 			}
@@ -119,7 +119,8 @@ public class SeffSimulationBehavior implements SimulationBehaviorExtension {
 	 * @param entity
 	 * @return
 	 */
-	private UserRequestFinished finishUserRequest(final SEFFInterpretationContext entity) {
+	private UserRequestFinished finishUserRequest(final SEFFInterpretationContext entity) { // entitiy ist der erste
+																							// erzeugte SEFF IC
 		final UserRequest userRequest = entity.getRequestProcessingContext().getUserRequest();
 		final UserInterpretationContext userInterpretationContext = entity.getRequestProcessingContext()
 				.getUserInterpretationContext();

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SeffSimulationBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SeffSimulationBehavior.java
@@ -119,8 +119,7 @@ public class SeffSimulationBehavior implements SimulationBehaviorExtension {
 	 * @param entity
 	 * @return
 	 */
-	private UserRequestFinished finishUserRequest(final SEFFInterpretationContext entity) { // entitiy ist der erste
-																							// erzeugte SEFF IC
+	private UserRequestFinished finishUserRequest(final SEFFInterpretationContext entity) {
 		final UserRequest userRequest = entity.getRequestProcessingContext().getUserRequest();
 		final UserInterpretationContext userInterpretationContext = entity.getRequestProcessingContext()
 				.getUserInterpretationContext();

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SystemSimulationBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SystemSimulationBehavior.java
@@ -236,8 +236,7 @@ public class SystemSimulationBehavior implements SimulationBehaviorExtension {
 			SimulatedStackHelper.addParameterToStackFrame(entity.getRequestFrom().getCurrentResultStackframe(),
 					entity.getOutputVariableUsages(), entity.getUser().getStack().currentStackFrame());
 
-			return Result.of(new SEFFInterpretationProgressed(
-					seffInterpretationContext.update().withCallOverWireRequest(null).build()));
+			return Result.of(new SEFFInterpretationProgressed(seffInterpretationContext));
 		}
 
 		final Optional<AssemblyContext> assemblyContext = this.systemRepository
@@ -249,13 +248,7 @@ public class SystemSimulationBehavior implements SimulationBehaviorExtension {
 		if (assemblyContext.isPresent() && providedRole.isPresent()) {
 			final RepositoryInterpreter interpreter = new RepositoryInterpreter(assemblyContext.get(),
 					entity.getSignature(), providedRole.get(), entity.getUser(), this.systemRepository,
-					Optional.of(entity.getRequestFrom()), cowSucceeded.getRequest(), new SimulatedStackframe<Object>()); // TODO
-																														// hier
-																														// nicht
-																														// getCaller
-																														// sondern
-																														// direct
-																														// RequestFrom.
+					Optional.of(entity.getRequestFrom()), cowSucceeded.getRequest(), new SimulatedStackframe<Object>());
 
 			/* Interpret the Component of the system. */
 			final Set<SEFFInterpretationProgressed> appearedEvents = interpreter

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SystemSimulationBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SystemSimulationBehavior.java
@@ -329,7 +329,7 @@ public class SystemSimulationBehavior implements SimulationBehaviorExtension {
 		if (assemblyContext.isPresent()) {
 			final RepositoryInterpreter interpreter = new RepositoryInterpreter(assemblyContext.get(),
 					entity.getSignature(), null, entity.getUser(), this.systemRepository,
-					entity.getRequestFrom().getCaller(), null, null);
+					Optional.of(entity.getRequestFrom()), null, null);
 
 			/* Interpret the Component of the system. */
 			final Set<SEFFInterpretationProgressed> appearedEvents = interpreter

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SystemSimulationBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SystemSimulationBehavior.java
@@ -228,16 +228,18 @@ public class SystemSimulationBehavior implements SimulationBehaviorExtension {
 			 * This is a reply to an already made request from a caller, so we need to go
 			 * back to the caller
 			 */
-			final SEFFInterpretationContext seffInterpretationContext = entity.getRequestFrom().getCaller()
-					.orElseThrow(() -> new IllegalStateException(
-							"Since the call came from somewhere else, the context of the caller must be present, but it isn't."));
+			final SEFFInterpretationContext seffInterpretationContext = entity.getRequestFrom();
+			// .orElseThrow(() -> new IllegalStateException(
+			// "Since the call came from somewhere else, the context of the caller must be
+			// present, but it isn't."));
 
 			/* Put the output variables to the parent stack */
 			SimulatedStackHelper.addParameterToStackFrame(entity.getRequestFrom().getCurrentResultStackframe(),
 					entity.getOutputVariableUsages(), entity.getUser().getStack().currentStackFrame());
 
 			return Result.of(new SEFFInterpretationProgressed(
-					seffInterpretationContext.update().withCallOverWireRequest(null).build()));
+					seffInterpretationContext.update().withCallOverWireRequest(null).build())); // COW ist schon
+																								// empty???
 		}
 
 		final Optional<AssemblyContext> assemblyContext = this.systemRepository
@@ -249,7 +251,13 @@ public class SystemSimulationBehavior implements SimulationBehaviorExtension {
 		if (assemblyContext.isPresent() && providedRole.isPresent()) {
 			final RepositoryInterpreter interpreter = new RepositoryInterpreter(assemblyContext.get(),
 					entity.getSignature(), providedRole.get(), entity.getUser(), this.systemRepository,
-					entity.getRequestFrom().getCaller(), cowSucceeded.getRequest(), new SimulatedStackframe<Object>());
+					Optional.of(entity.getRequestFrom()), cowSucceeded.getRequest(), new SimulatedStackframe<Object>()); // TODO
+																														// hier
+																														// nicht
+																														// getCaller
+																														// sondern
+																														// direct
+																														// RequestFrom.
 
 			/* Interpret the Component of the system. */
 			final Set<SEFFInterpretationProgressed> appearedEvents = interpreter
@@ -278,7 +286,7 @@ public class SystemSimulationBehavior implements SimulationBehaviorExtension {
 	 * requested could not be handled. The main use case is: resources/assemblies
 	 * that previously existed, do not exist anymore, causing null-pointers when
 	 * accessing state.
-	 * 
+	 *
 	 * @param demandRequestAborted
 	 * @return UserAborted event.
 	 */
@@ -293,7 +301,7 @@ public class SystemSimulationBehavior implements SimulationBehaviorExtension {
 	/**
 	 * Helper method to traverse the SeffInterpretationContext and find the
 	 * UserInterpretationContext.
-	 * 
+	 *
 	 * @param seffContext
 	 * @return
 	 * @throws NoSuchElementException

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SystemSimulationBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SystemSimulationBehavior.java
@@ -228,9 +228,6 @@ public class SystemSimulationBehavior implements SimulationBehaviorExtension {
 			 * back to the caller
 			 */
 			final SEFFInterpretationContext seffInterpretationContext = entity.getRequestFrom();
-			// .orElseThrow(() -> new IllegalStateException(
-			// "Since the call came from somewhere else, the context of the caller must be
-			// present, but it isn't."));
 
 			/* Put the output variables to the parent stack */
 			SimulatedStackHelper.addParameterToStackFrame(entity.getRequestFrom().getCurrentResultStackframe(),

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SystemSimulationBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SystemSimulationBehavior.java
@@ -33,7 +33,6 @@ import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.entities.Use
 import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.entities.interpretationcontext.UserInterpretationContext;
 import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.events.UserAborted;
 import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.events.UserEntryRequested;
-import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.events.UserFinished;
 import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
 import org.palladiosimulator.analyzer.slingshot.common.utils.SimulatedStackHelper;
 import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorExtension;
@@ -205,11 +204,11 @@ public class SystemSimulationBehavior implements SimulationBehaviorExtension {
 	 * If either the {@code AssemblyContext} or {@code OperationProvidedRole} are
 	 * missing, e.g. due to a scale while the call was processed in the linking
 	 * resource, the Request cannot be completed. Thus this operation published a
-	 * {@link UserFinished} event for the user of the request, such that the request
+	 * {@link UserAborted} event for the user of the request, such that the request
 	 * finishes gracefully.
 	 *
 	 * This is especially important for closed workloads, where no new users enter
-	 * the system, i.e. if the {@link UserFinished} is not published the simulation
+	 * the system, i.e. if the {@link UserAborted} is not published the simulation
 	 * "looses" the user entirely.
 	 *
 	 * It is probably less important for open workloads, as new users keep entering
@@ -238,8 +237,7 @@ public class SystemSimulationBehavior implements SimulationBehaviorExtension {
 					entity.getOutputVariableUsages(), entity.getUser().getStack().currentStackFrame());
 
 			return Result.of(new SEFFInterpretationProgressed(
-					seffInterpretationContext.update().withCallOverWireRequest(null).build())); // COW ist schon
-																								// empty???
+					seffInterpretationContext.update().withCallOverWireRequest(null).build()));
 		}
 
 		final Optional<AssemblyContext> assemblyContext = this.systemRepository

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/interpreters/SeffInterpreter.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/interpreters/SeffInterpreter.java
@@ -126,7 +126,8 @@ public class SeffInterpreter extends SeffSwitch<Set<SEFFInterpreted>> {
 		final SEFFInterpretationContext childContext = this.context.createChildContext()
 				.withBehaviorContext(holder)
 				.withRequestProcessingContext(this.context.getRequestProcessingContext())
-				.withCaller(this.context.getCaller())
+				// .withCaller(this.context.getCaller()) // imho, children should not have
+				// callers, only parents.
 				.withAssemblyContext(this.context.getAssemblyContext())
 				.build();
 

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/interpreters/SeffInterpreter.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/interpreters/SeffInterpreter.java
@@ -218,9 +218,7 @@ public class SeffInterpreter extends SeffSwitch<Set<SEFFInterpreted>> {
 				.withRequiredRole(requiredRole)
 				.withSignature(calledServiceSignature)
 				.withUser(this.context.getRequestProcessingContext().getUser())
-				.withRequestFrom(this.context.update()
-						.withCaller(this.context.getCaller())// fixxing
-						.build())
+				.withRequestFrom(this.context.update().build())
 				.build();
 
 
@@ -313,7 +311,7 @@ public class SeffInterpreter extends SeffSwitch<Set<SEFFInterpreted>> {
 					.withRequiredRole(call.getRequiredRole__InfrastructureCall())
 					.withSignature(call.getSignature__InfrastructureCall())
 					.withUser(this.context.getRequestProcessingContext().getUser())
-					.withRequestFrom(this.context.update().withCaller(this.context.getCaller()).build()).build();
+					.withRequestFrom(this.context.update().build()).build();
 
 			return Set.of(new SEFFInfrastructureCalled(request));
 		}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/interpreters/SeffInterpreter.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/interpreters/SeffInterpreter.java
@@ -162,7 +162,7 @@ public class SeffInterpreter extends SeffSwitch<Set<SEFFInterpreted>> {
 				.withBehaviorContext(holder)
 				.withRequestProcessingContext(this.context.getRequestProcessingContext())
 				.withCaller(this.context.getCaller()).withAssemblyContext(this.context.getAssemblyContext()).build();
-		
+
 		return Set.of(new SEFFChildInterpretationStarted(childContext));
 	}
 
@@ -219,7 +219,7 @@ public class SeffInterpreter extends SeffSwitch<Set<SEFFInterpreted>> {
 				.withSignature(calledServiceSignature)
 				.withUser(this.context.getRequestProcessingContext().getUser())
 				.withRequestFrom(this.context.update()
-						.withCaller(this.context)
+						.withCaller(this.context.getCaller())// fixxing
 						.build())
 				.build();
 
@@ -313,7 +313,7 @@ public class SeffInterpreter extends SeffSwitch<Set<SEFFInterpreted>> {
 					.withRequiredRole(call.getRequiredRole__InfrastructureCall())
 					.withSignature(call.getSignature__InfrastructureCall())
 					.withUser(this.context.getRequestProcessingContext().getUser())
-					.withRequestFrom(this.context.update().withCaller(this.context).build()).build();
+					.withRequestFrom(this.context.update().withCaller(this.context.getCaller()).build()).build();
 
 			return Set.of(new SEFFInfrastructureCalled(request));
 		}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/interpreters/SeffInterpreter.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/interpreters/SeffInterpreter.java
@@ -162,7 +162,9 @@ public class SeffInterpreter extends SeffSwitch<Set<SEFFInterpreted>> {
 		final SEFFInterpretationContext childContext = this.context.createChildContext()
 				.withBehaviorContext(holder)
 				.withRequestProcessingContext(this.context.getRequestProcessingContext())
-				.withCaller(this.context.getCaller()).withAssemblyContext(this.context.getAssemblyContext()).build();
+				.withCaller(this.context.getCaller())
+				.withAssemblyContext(this.context.getAssemblyContext())
+				.build();
 
 		return Set.of(new SEFFChildInterpretationStarted(childContext));
 	}
@@ -221,7 +223,6 @@ public class SeffInterpreter extends SeffSwitch<Set<SEFFInterpreted>> {
 				.withUser(this.context.getRequestProcessingContext().getUser())
 				.withRequestFrom(this.context.update().build())
 				.build();
-
 
 		return Set.of(new SEFFExternalActionCalled(entryRequest));
 	}


### PR DESCRIPTION
# Current
## Caller Self-Reference
`SEFFInterpretationContext`s (SEFFIC) that contain an `ExternalCallAction` get updated to be their own caller, such that we end up with object relations like this: 

![image](https://github.com/PalladioSimulator/Palladio-Analyzer-Slingshot-Extension-PCM-Core/assets/44230629/ef5a2e31-6812-4aa2-9509-9b955e2b604d)

PCM model, colours correpond to the SEFF ICs.
![image](https://github.com/PalladioSimulator/Palladio-Analyzer-Slingshot-Extension-PCM-Core/assets/44230629/073982a7-8a6e-40c4-bddd-f09783272b25)


All blue SEFFICs are copies of each other, created when calling `update`. Note, that the copies reference the original as _caller_ which sematically makes zero sense. 


## Reset of `CallOverwireRequest` in `onCallOverWireSucceeded`
When returning from a call the callOverwireRequest (COWR) of the caller gets reset to `null`. This is wrong, because semantically the COWR of a SEFFIC is the request, by which the SEFFIC was called. The example given above works just fine, but in case of nested external calls (see figure below), returning from the SEFFIC that is both callee and caller (green) to its caller breaks. 

![image](https://github.com/PalladioSimulator/Palladio-Analyzer-Slingshot-Extension-PCM-Core/assets/44230629/05a12853-6aec-4c85-bf74-345b12301af3)

# New
## Caller Self-Reference
Copied SEFFICs do no longer reference their original as caller. As a follow up, the "unwrapping" of SEFFIC was adapted as well. 

object relation is now like this:
![image](https://github.com/PalladioSimulator/Palladio-Analyzer-Slingshot-Extension-PCM-Core/assets/44230629/d0f5fe4b-8805-48f1-95c6-2c01a28def55)

## Reset of `CallOverwireRequest` in `onCallOverWireSucceeded`
Removed the reset. Now even nested external calls can return to their caller. 

# Misc
* Also fixed the problems mentioned above for Infrastructure Calls. 
* Not yet sure, whether the fixes of this PR cause Problems with the `StackContext`. However, the `StackContext` is broken anyway, thus i suggest to ignore the Stack for this PR and fix it separately after merging this PR.
