### PR TITLE
consider signature when differentiating AssemblyOperationMeassuringPoints

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/AssemblyOperationCompoundKey.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/AssemblyOperationCompoundKey.java
@@ -22,9 +22,9 @@ public final class AssemblyOperationCompoundKey {
 	private final ProvidedRole providedRole;
 	private final Signature signature;
 
-	private AssemblyOperationCompoundKey(final AssemblyContext resourceContainer, final ProvidedRole providedRole,
+	private AssemblyOperationCompoundKey(final AssemblyContext assemblyContext, final ProvidedRole providedRole,
 			final Signature signature) {
-		this.assemblyContext = resourceContainer;
+		this.assemblyContext = assemblyContext;
 		this.providedRole = providedRole;
 		this.signature = signature;
 	}
@@ -70,8 +70,8 @@ public final class AssemblyOperationCompoundKey {
 				context.getRequestProcessingContext().getProvidedRole(), sig);
 	}
 
-	public static AssemblyOperationCompoundKey of(final AssemblyContext resourceContainer,
+	public static AssemblyOperationCompoundKey of(final AssemblyContext assemblyContext,
 			final ProvidedRole providedRole, final Signature signature) {
-		return new AssemblyOperationCompoundKey(resourceContainer, providedRole, signature);
+		return new AssemblyOperationCompoundKey(assemblyContext, providedRole, signature);
 	}
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/AssemblyOperationCompoundKey.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/AssemblyOperationCompoundKey.java
@@ -2,8 +2,10 @@ package org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monit
 
 import java.util.Objects;
 
+import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.seff.SEFFInterpretationContext;
 import org.palladiosimulator.pcm.core.composition.AssemblyContext;
 import org.palladiosimulator.pcm.repository.ProvidedRole;
+import org.palladiosimulator.pcm.repository.Signature;
 
 /**
  *
@@ -18,15 +20,18 @@ public final class AssemblyOperationCompoundKey {
 
 	private final AssemblyContext assemblyContext;
 	private final ProvidedRole providedRole;
+	private final Signature signature;
 
-	private AssemblyOperationCompoundKey(final AssemblyContext resourceContainer, final ProvidedRole providedRole) {
+	private AssemblyOperationCompoundKey(final AssemblyContext resourceContainer, final ProvidedRole providedRole,
+			final Signature signature) {
 		this.assemblyContext = resourceContainer;
 		this.providedRole = providedRole;
+		this.signature = signature;
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(this.assemblyContext.getId(), this.providedRole.getId());
+		return Objects.hash(this.assemblyContext.getId(), this.providedRole.getId(), this.signature.getId());
 	}
 
 	@Override
@@ -39,7 +44,8 @@ public final class AssemblyOperationCompoundKey {
 		}
 		final AssemblyOperationCompoundKey other = (AssemblyOperationCompoundKey) obj;
 		return Objects.equals(this.assemblyContext.getId(), other.assemblyContext.getId())
-				&& Objects.equals(this.providedRole.getId(), other.providedRole.getId());
+				&& Objects.equals(this.providedRole.getId(), other.providedRole.getId())
+				&& Objects.equals(this.signature.getId(), other.signature.getId());
 	}
 
 	@Override
@@ -47,8 +53,25 @@ public final class AssemblyOperationCompoundKey {
 		return this.assemblyContext.getId() + ":" + this.providedRole.getId();
 	}
 
+	public static AssemblyOperationCompoundKey of(final SEFFInterpretationContext context) {
+
+		Signature sig = null;
+		if (context.getRequestProcessingContext().getUserRequest() != null) {
+			sig = context.getRequestProcessingContext().getUserRequest().getOperationSignature();
+		} else if (context.getCallOverWireRequest().isPresent()) {
+			sig = context.getCallOverWireRequest().get().getSignature();
+		} else {
+			throw new IllegalArgumentException(String.format(
+					"Cannot determine Signature of SEFFInterpretationContext %s, as their is neither a UserRequest, nor a CallOverWireRequest.",
+					context.toString()));
+		}
+
+		return new AssemblyOperationCompoundKey(context.getAssemblyContext(),
+				context.getRequestProcessingContext().getProvidedRole(), sig);
+	}
+
 	public static AssemblyOperationCompoundKey of(final AssemblyContext resourceContainer,
-			final ProvidedRole providedRole) {
-		return new AssemblyOperationCompoundKey(resourceContainer, providedRole);
+			final ProvidedRole providedRole, final Signature signature) {
+		return new AssemblyOperationCompoundKey(resourceContainer, providedRole, signature);
 	}
 }


### PR DESCRIPTION
## Current Beahviour
1. I have a Component, that offers multiple operations (-> `Signature`)
2. I define `AssemblyOperationMeasuringPoint`s for each signature. 
3. I run simulation. 
4. In the experiments results, i get an recorder for each defined MP, but only one of them received measurements.

### Cause of the Problem
Current implementation of the Operation Response Time Monitor disregard the `Signature` defined in the MP. 

## New Behaviour
The `Signature` of the MPs is considered as well. All measured values end up at their respective calculator/recorder. 
