### PR TITLE
relying on model changes from core rather than spd interpreter

### DIFF
--- a/bundles/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/META-INF/MANIFEST.MF
@@ -13,5 +13,4 @@ Require-Bundle: org.palladiosimulator.analyzer.slingshot.core;bundle-version="1.
  org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data;bundle-version="1.0.0",
  org.palladiosimulator.analyzer.slingshot.monitor;bundle-version="1.0.0",
  org.palladiosimulator.analyzer.slingshot.monitor.utils,
- org.palladiosimulator.analyzer.slingshot.behavior.spd.data;bundle-version="1.0.0",
  org.palladiosimulator.spd.measuringpoint;bundle-version="1.0.0"

--- a/bundles/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/monitor/NumberOfElementsMonitorBehavior.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/monitor/NumberOfElementsMonitorBehavior.java
@@ -9,8 +9,8 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.probes.NumberOfElementsInElasitcInfrastuctureProbe;
-import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.ModelAdjusted;
 import org.palladiosimulator.analyzer.slingshot.common.annotations.Nullable;
+import org.palladiosimulator.analyzer.slingshot.common.events.modelchanges.ModelAdjusted;
 import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorExtension;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.Subscribe;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.eventcontract.EventCardinality;

--- a/bundles/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/META-INF/MANIFEST.MF
@@ -13,7 +13,6 @@ Require-Bundle: org.palladiosimulator.analyzer.slingshot.core;bundle-version="1.
  de.uka.ipd.sdq.simucomframework,
  org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data,
  de.uka.ipd.sdq.simucomframework.variables,
- org.palladiosimulator.analyzer.slingshot.behavior.spd.data,
  org.palladiosimulator.analyzer.slingshot.behavior.usagesimulation.data,
  org.palladiosimulator.analyzer.slingshot.common.utils
 Export-Package: org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation,

--- a/bundles/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/ResourceSimulation.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/ResourceSimulation.java
@@ -32,9 +32,6 @@ import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.reso
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.resources.passive.PassiveResourceCompoundKey;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.resources.passive.PassiveResourceTable;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.resources.passive.SimplePassiveResource;
-import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.ModelAdjusted;
-import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.adjustment.AllocationChange;
-import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.adjustment.ResourceEnvironmentChange;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.resource.CallOverWireRequest;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.resource.ResourceDemandRequest;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.resource.ResourceDemandRequest.ResourceType;
@@ -48,6 +45,9 @@ import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.ResourceDemandRequested;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.ResourceDemandRequestAborted;
 import org.palladiosimulator.analyzer.slingshot.common.events.AbstractSimulationEvent;
+import org.palladiosimulator.analyzer.slingshot.common.events.modelchanges.AllocationChange;
+import org.palladiosimulator.analyzer.slingshot.common.events.modelchanges.ModelAdjusted;
+import org.palladiosimulator.analyzer.slingshot.common.events.modelchanges.ResourceEnvironmentChange;
 import org.palladiosimulator.analyzer.slingshot.core.events.SimulationFinished;
 import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorExtension;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.Subscribe;

--- a/bundles/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/META-INF/MANIFEST.MF
@@ -12,6 +12,5 @@ Require-Bundle: org.palladiosimulator.analyzer.slingshot.core,
  org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.data;bundle-version="1.0.0",
  org.palladiosimulator.analyzer.slingshot.monitor;bundle-version="1.0.0",
  org.palladiosimulator.spd.measuringpoint;bundle-version="1.0.0",
- org.palladiosimulator.analyzer.slingshot.behavior.spd.data;bundle-version="1.0.0",
  org.palladiosimulator.analyzer.slingshot.monitor.utils;bundle-version="1.0.0",
  org.palladiosimulator.analyzer.slingshot.behavior.usagesimulation.data

--- a/bundles/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/NumberOfElementsMonitorBehavior.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/monitor/NumberOfElementsMonitorBehavior.java
@@ -8,10 +8,10 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.ModelAdjusted;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor.probes.NumberOfElementsInCompetingConsumerGroupProbe;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.monitor.probes.NumberOfElementsInServiceGroupProbe;
 import org.palladiosimulator.analyzer.slingshot.common.annotations.Nullable;
+import org.palladiosimulator.analyzer.slingshot.common.events.modelchanges.ModelAdjusted;
 import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorExtension;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.Subscribe;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.eventcontract.EventCardinality;


### PR DESCRIPTION
Because model changes events have been pushed down to the core, the PCM-Core should rely on the definitions in Core rather in SPD-Interpreter. requires https://github.com/PalladioSimulator/Palladio-Analyzer-Slingshot/pull/26 