### PR TITLE
Refactor `SystemModelRepository`

### DIFF
--- a/bundles/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SystemSimulationBehavior.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/SystemSimulationBehavior.java
@@ -44,6 +44,7 @@ import org.palladiosimulator.pcm.core.composition.ProvidedDelegationConnector;
 import org.palladiosimulator.pcm.parameter.VariableUsage;
 import org.palladiosimulator.pcm.repository.OperationProvidedRole;
 import org.palladiosimulator.pcm.repository.OperationSignature;
+import org.palladiosimulator.pcm.repository.ProvidedRole;
 import org.palladiosimulator.pcm.repository.RequiredRole;
 import org.palladiosimulator.pcm.seff.AbstractAction;
 import org.palladiosimulator.pcm.seff.InternalAction;
@@ -110,9 +111,12 @@ public class SystemSimulationBehavior implements SimulationBehaviorExtension {
 			SimulatedStackHelper.createAndPushNewStackFrame(request.getUser().getStack(), variableUsages);
 			// further stack frames are pushed inside the RepositoryInterpreter.
 
+			final ProvidedRole innerRole = connectedProvidedDelegationConnector.get()
+					.getInnerProvidedRole_ProvidedDelegationConnector();
+
 			// TODO and here it should be the other provided role.
 			final RepositoryInterpreter interpreter = new RepositoryInterpreter(assemblyContextByProvidedRole,
-					operationSignature, operationProvidedRole, request.getUser(), systemRepository, Optional.empty(),
+					operationSignature, innerRole, request.getUser(), systemRepository, Optional.empty(),
 					null, new SimulatedStackframe<Object>(), userEntryRequested.getUserInterpretationContext(),
 					request);
 

--- a/bundles/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/repository/SystemModelRepository.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation/src/org/palladiosimulator/analyzer/slingshot/behavior/systemsimulation/repository/SystemModelRepository.java
@@ -2,14 +2,11 @@ package org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.repos
 
 import java.util.Optional;
 
+import org.palladiosimulator.pcm.core.composition.AssemblyConnector;
 import org.palladiosimulator.pcm.core.composition.AssemblyContext;
 import org.palladiosimulator.pcm.core.composition.ProvidedDelegationConnector;
-import org.palladiosimulator.pcm.repository.OperationProvidedRole;
 import org.palladiosimulator.pcm.repository.ProvidedRole;
 import org.palladiosimulator.pcm.repository.RequiredRole;
-import org.palladiosimulator.pcm.repository.Role;
-import org.palladiosimulator.pcm.repository.Signature;
-import org.palladiosimulator.pcm.seff.ServiceEffectSpecification;
 import org.palladiosimulator.pcm.system.System;
 
 import com.google.inject.ImplementedBy;
@@ -22,7 +19,7 @@ import com.google.inject.ImplementedBy;
  * The repository allows a direct access to the model instead of using a
  * Switch-class.
  *
- * @author Julijan Katic
+ * @author Julijan Katic, Sarah Stieß
  */
 @ImplementedBy(SystemModelRepositoryImpl.class)
 public interface SystemModelRepository {
@@ -36,29 +33,6 @@ public interface SystemModelRepository {
 	void load(System system);
 
 	/**
-	 * Finds the service effect specification from a required role and a signature.
-	 * This is useful if a SEFF calls another SEFF from a Required Role.
-	 *
-	 * @param requiredRole The required role in which the SEFF lies.
-	 * @param signature    The specific method to call.
-	 * @return The SEFF of the method from that required role if it exists.
-	 */
-	Optional<ServiceEffectSpecification> findSeffFromRequiredRole(RequiredRole requiredRole, Signature signature);
-
-	/**
-	 * Returns the Assembly Context of a required role. The required role is
-	 * attached to a specific assembly context, which in turn contains the component
-	 * containg the SEFFs.
-	 *
-	 * @param requiredRole The required role (connector) attached to the assembly
-	 *                     context which should be found.
-	 * @return The assembly context if it exists.
-	 */
-	Optional<AssemblyContext> findAssemblyContextFromRequiredRole(RequiredRole requiredRole);
-
-	Optional<OperationProvidedRole> findProvidedRoleFromRequiredRole(final RequiredRole requiredRole);
-
-	/**
 	 * Get the delegation connector from a provided role. The provided role is the
 	 * role attached to the whole system, not the role attached to an (inner)
 	 * assembly context.
@@ -69,59 +43,28 @@ public interface SystemModelRepository {
 	Optional<ProvidedDelegationConnector> getConnectedProvidedDelegationConnector(ProvidedRole providedRole);
 
 	/**
-	 * Returns the SEFF of a delegation connector at the certain signature. This is
-	 * useful if someone ones to enter the system and call a service from the
-	 * outside. This method requires to know the delegation already. If only the
-	 * provided role (of the system!) is known, use {@link #getSeffFromProvidedRole}
-	 *
-	 * @param connector The delegation connector connecting the (outer) provided
-	 *                  role from the system to the inner provided role to a certain
-	 *                  assembly context.
-	 * @param signature The signature at which the SEFF lies.
-	 * @return The SEFF if it exists.
-	 */
-	Optional<ServiceEffectSpecification> getDelegatedComponentSeff(ProvidedDelegationConnector connector,
-			Signature signature);
-
-	/**
-	 * Returns the SEFF from a provided role at the signature. In this case, the
-	 * provided role could be either a provided role of the overall system that is
-	 * delegated to an inner service, or it already points to a concrete provided
-	 * role of an assembly context.
-	 *
-	 * @param role      The provided role in which the service should be found.
-	 * @param signature the signature at which the SEFF lies.
-	 * @return The SEFF if it exists.
-	 */
-	Optional<ServiceEffectSpecification> getSeffFromProvidedRole(ProvidedRole role, Signature signature);
-
-	/**
-	 * Returns the Assembly Context onto which the provided role is attached.
-	 *
-	 * @param role the provided role.
-	 * @return the assembly context.
-	 */
-	Optional<AssemblyContext> findAssemblyContextByProvidedRole(ProvidedRole role);
-
-	/**
-	 * TODO
+	 * Finds the {@link AssemblyConnector} that connects the required role of the
+	 * requiring {@link AssemblyContext} to the provided role of another context.
 	 *
 	 * @param requiredRole
-	 * @return
+	 * @param requiringContext
+	 * @return an {@link AssemblyConnector} that connects the required role of the
+	 *         requiring context to a providing one, or an empty optional if none
+	 *         exists.
 	 */
-	Optional<AssemblyContext> findInfrastructureAssemblyContextFromRequiredRole(RequiredRole requiredRole);
+	Optional<AssemblyConnector> findOutgoingAssemblyConnector(RequiredRole requiredRole,
+			AssemblyContext requiringContext);
 
 	/**
-	 * A short-cut method to find the assembly context by any role, regardless of
-	 * whether it is a required or a provided role. However, the role must be either
-	 * one of them.
+	 * Finds the connected {@link AssemblyContext} for an infrastructure call.
 	 *
-	 * @param role The role attached to an assembly context.
-	 * @return The attached assembly context.
-	 * @see #findAssemblyContextByProvidedRole(ProvidedRole)
-	 * @see #findAssemblyContextFromRequiredRole(RequiredRole)
+	 * @param requiredRole
+	 * @param requiringContext
+	 * @return assembly context providing for the requiring assembly context, or an
+	 *         empty optional if none exists.
 	 */
-	Optional<AssemblyContext> findAssemblyContextByRole(Role role);
+	Optional<AssemblyContext> findInfrastructureAssemblyContextFromRequiredRole(RequiredRole requiredRole,
+			AssemblyContext requiringContext);
 
 	/**
 	 * Returns the default instance of this interface.


### PR DESCRIPTION
This PR will close #84.  

## Current Behaviour

c.f.  #84.

## New Behaviour

When matching callees for a call, we do not only look at the roles, but also at the requiring assemblies, thereby making sure that we call the *connected* assembly and not just any assembly, that provides the required role. 

Also (2nd commit) i switched to the inner role, when entering a system with an entrylevel call. Before, we put the outer role into the request contexts an everything, but in my opinion it is more consistent to use the inner role once we are *inside* the system. 