### PR TITLE
removed copy creation of eobject.

### DIFF
--- a/bundles/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/entities/jobs/ActiveJob.java
+++ b/bundles/org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.data/src/org/palladiosimulator/analyzer/slingshot/behavior/resourcesimulation/entities/jobs/ActiveJob.java
@@ -5,7 +5,6 @@ import java.util.stream.Collectors;
 
 import javax.annotation.processing.Generated;
 
-import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.entities.resource.ResourceDemandRequest;
 import org.palladiosimulator.pcm.allocation.AllocationContext;
 import org.palladiosimulator.pcm.resourceenvironment.ProcessingResourceSpecification;
@@ -42,7 +41,7 @@ public class ActiveJob extends Job {
 	}
 
 	public ProcessingResourceType getProcessingResourceType() {
-		return EcoreUtil.copy(this.processingResourceType);
+		return this.processingResourceType;
 	}
 
 	public ResourceDemandRequest getRequest() {


### PR DESCRIPTION
### Current Behaviour

`getProcessingResourceType()` in `ActiveJob` creates a copy and returns a copy of the processing resource type. 
However, the created copy is not included in any resource, which is a inconsistency an might become problematic later on. 
In fact, it became problematic for MENTOR, where i need to access that element's resource.

### New Behaviour

No more copying, return the original eObject. Reasonable to me, because (1) no more parentless eObjects and (2) we do not copy any other elements, except for the measuring points, which we copy *into* another resource.