### PR TITLE
Migrate to parent POM version 0.10.0

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -5,9 +5,4 @@
 		<artifactId>tycho-build</artifactId>
 		<version>2.7.5</version>
 	</extension>
-	<extension>
-		<groupId>org.palladiosimulator</groupId>
-		<artifactId>tycho-tp-refresh-maven-plugin</artifactId>
-		<version>0.2.6</version>
-	</extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.palladiosimulator</groupId>
 		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.9.0</version>
+		<version>0.10.0</version>
 	</parent>
 	<groupId>org.palladiosimulator.analyzer.slingshot.behavior.pcm</groupId>
 	<artifactId>parent</artifactId>	
@@ -14,7 +14,7 @@
 	<packaging>pom</packaging>
 	
 	<properties>
-		<org.palladiosimulator.maven.tychotprefresh.tplocation.2>${project.basedir}/releng/org.palladiosimulator.analyzer.slingshot.behavior.pcm.targetplatform/tp.target</org.palladiosimulator.maven.tychotprefresh.tplocation.2>
+		<targetPlatform.relativePath>releng/org.palladiosimulator.analyzer.slingshot.behavior.pcm.targetplatform/tp.target</targetPlatform.relativePath>
 	</properties>
 	
 	<modules>

--- a/releng/org.palladiosimulator.analyzer.slingshot.behavior.pcm.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.analyzer.slingshot.behavior.pcm.targetplatform/tp.target
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="org.palladiosimulator.analyzer.slingshot Target Platform" sequenceNumber="1">
+<?pde version="3.8"?><target name="org.palladiosimulator.analyzer.slingshot Target Platform" sequenceNumber="2">
 	<locations>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<location type="Target" uri="mvn:org.palladiosimulator:palladio-target-platforms:0.1.0:target:palladio-2023-03"/>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<repository location="https://updatesite.palladio-simulator.com/palladio-build-updatesite/releases/latest/"/>
 			<unit id="ca.umontreal.iro.ssj.feature.feature.group" version="3.3.1"/>
 			<unit id="de.uka.ipd.sdq.workflow.feature.mdsd.feature.group" version="0.0.0"/>
@@ -12,7 +13,7 @@
 			<unit id="org.palladiosimulator.monitorrepository.feature.feature.group" version="0.0.0"/>
 			<unit id="org.scaledl.usageevolution.feature.feature.group" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/tools/orbit/downloads/2023-03/"/>
 			<unit id="org.reactivestreams" version="0.0.0"/>
 			<unit id="net.bytebuddy.byte-buddy" version="0.0.0"/>
@@ -21,16 +22,16 @@
 			<unit id="org.mockito.mockito-core" version="0.0.0"/>
 			<unit id="org.objenesis" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-slingshot/nightly/"/>
 			<unit id="org.palladiosimulator.analyzer.slingshot.feature.feature.group" version="0.0.0"/>
 			<unit id="org.palladiosimulator.analyzer.slingshot.ui.feature.feature.group" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<repository location="https://updatesite.palladio-simulator.com/palladio-addons-spd-metamodel/nightly/"/>
 			<unit id="org.palladiosimulator.spd.feature.feature.group" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-slingshot-extension-monitoring/nightly/"/>
 			<unit id="org.palladiosimulator.analyzer.slingshot.extension.monitoring.feature.feature.group" version="0.0.0"/>
 		</location>

--- a/releng/org.palladiosimulator.analyzer.slingshot.behavior.pcm.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.analyzer.slingshot.behavior.pcm.targetplatform/tp.target
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?><target name="org.palladiosimulator.analyzer.slingshot Target Platform" sequenceNumber="1">
-<locations>
-	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="https://updatesite.palladio-simulator.com/palladio-build-updatesite/releases/latest/"/>
-		<unit id="ca.umontreal.iro.ssj.feature.feature.group" version="3.3.1"/>
-		<unit id="de.uka.ipd.sdq.workflow.feature.mdsd.feature.group" version="0.0.0"/>
-		<unit id="org.palladiosimulator.edp2.ui.feature.feature.group" version="0.0.0"/>
-		<unit id="org.palladiosimulator.pcm.edp2.measuringpoint.feature.feature.group" version="0.0.0"/>
-		<unit id="org.palladiosimulator.pcm.feature.feature.group" version="0.0.0"/>
-		<unit id="org.palladiosimulator.simucom.feature.feature.group" version="0.0.0"/>
-		<unit id="org.palladiosimulator.monitorrepository.feature.feature.group" version="0.0.0"/>
-		<unit id="org.scaledl.usageevolution.feature.feature.group" version="0.0.0"/>
-	</location>
-	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/2023-03/"/>
-		<unit id="org.reactivestreams" version="0.0.0"/>
-		<unit id="net.bytebuddy.byte-buddy" version="0.0.0"/>
-		<unit id="net.bytebuddy.byte-buddy-agent" version="0.0.0"/>
-		<unit id="org.hamcrest.library" version="0.0.0"/>
-		<unit id="org.mockito.mockito-core" version="0.0.0"/>
-		<unit id="org.objenesis" version="0.0.0"/>
-	</location>
-	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-slingshot/nightly/"/>
-		<unit id="org.palladiosimulator.analyzer.slingshot.feature.feature.group" version="0.0.0"/>
-		<unit id="org.palladiosimulator.analyzer.slingshot.ui.feature.feature.group" version="0.0.0"/>
-	</location>
-	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="https://updatesite.palladio-simulator.com/palladio-addons-spd-metamodel/nightly/"/>
-		<unit id="org.palladiosimulator.spd.feature.feature.group" version="0.0.0"/>
-	</location>
+	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-slingshot-extension-monitoring/nightly/"/>
-		<unit id="org.palladiosimulator.analyzer.slingshot.extension.monitoring.feature.feature.group" version="0.0.0"/>
-	</location>
-</locations>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-build-updatesite/releases/latest/"/>
+			<unit id="ca.umontreal.iro.ssj.feature.feature.group" version="3.3.1"/>
+			<unit id="de.uka.ipd.sdq.workflow.feature.mdsd.feature.group" version="0.0.0"/>
+			<unit id="org.palladiosimulator.edp2.ui.feature.feature.group" version="0.0.0"/>
+			<unit id="org.palladiosimulator.pcm.edp2.measuringpoint.feature.feature.group" version="0.0.0"/>
+			<unit id="org.palladiosimulator.pcm.feature.feature.group" version="0.0.0"/>
+			<unit id="org.palladiosimulator.simucom.feature.feature.group" version="0.0.0"/>
+			<unit id="org.palladiosimulator.monitorrepository.feature.feature.group" version="0.0.0"/>
+			<unit id="org.scaledl.usageevolution.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2023-03/"/>
+			<unit id="org.reactivestreams" version="0.0.0"/>
+			<unit id="net.bytebuddy.byte-buddy" version="0.0.0"/>
+			<unit id="net.bytebuddy.byte-buddy-agent" version="0.0.0"/>
+			<unit id="org.hamcrest.library" version="0.0.0"/>
+			<unit id="org.mockito.mockito-core" version="0.0.0"/>
+			<unit id="org.objenesis" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-slingshot/nightly/"/>
+			<unit id="org.palladiosimulator.analyzer.slingshot.feature.feature.group" version="0.0.0"/>
+			<unit id="org.palladiosimulator.analyzer.slingshot.ui.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-addons-spd-metamodel/nightly/"/>
+			<unit id="org.palladiosimulator.spd.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-analyzer-slingshot-extension-monitoring/nightly/"/>
+			<unit id="org.palladiosimulator.analyzer.slingshot.extension.monitoring.feature.feature.group" version="0.0.0"/>
+		</location>
+	</locations>
 </target>


### PR DESCRIPTION
### Overview
- Migrate from parent POM version `0.9.0` to the new parent POM version `0.10.0`
- Locally verified build success

### Changes
- In `pom.xml`:
  - Parent POM updated from `0.9.0` to `0.10.0`  
  - Renamed property `org.palladiosimulator.maven.tychotprefresh.tplocation.2` to `targetPlatform.relativePath` and trimmed its path value to start at `releng`  
- In `.mvn/extensions.xml`:
  - Removed `<extension>` block for `org.palladiosimulator:tycho-tp-refresh-maven-plugin`  
- In the target platform `tp.target`:
  - Inserted new `<location>` with URI `mvn:org.palladiosimulator:palladio-target-platforms:0.1.0:target:palladio-2023-03`, since the Palladio target platform is now decoupled from the parent POM  
  - Unified all `includeSource` attributes by setting them to `false`, as the value must be the same across all locations to prevent resolution failure  
  - Removed specifics of the `tycho-tp-refresh-maven-plugin` to be standard-compliant:  
    - Removed any `<location filter="release">` entries  
    - Removed `filter="nightly"` attributes  
    - Removed all `refresh="true"` attributes and, where present, set each `<unit>`’s `version` attribute to `0.0.0`  
  - Added indentation to improve readability